### PR TITLE
Remove wrong declaration of ~DirtyList as pure virtual

### DIFF
--- a/src/Sync/DirtyList.h
+++ b/src/Sync/DirtyList.h
@@ -24,7 +24,7 @@ class DirtyList
 {
     public:
         DirtyList() : errorAbort(false) {}
-        virtual ~DirtyList() = 0;
+        virtual ~DirtyList();
         virtual bool add(Feature* F) = 0;
         virtual bool update(Feature* F) = 0;
         virtual bool erase(Feature* F) = 0;


### PR DESCRIPTION
DirtyList.cpp actually gives the destructor a body, so declaring it as pure virtual is wrong.
(I wonder why did that even work.)