### PR TITLE
FIX: Replace bashism in Config.pri

### DIFF
--- a/src/Config.pri
+++ b/src/Config.pri
@@ -19,7 +19,7 @@ CONFIG(release,debug|release) {
 win32|macx {
     system(echo $${LITERAL_HASH}define SVNREV $${SVNREV} > revision.h )
 } else {
-    system('echo -n "$${LITERAL_HASH}define SVNREV $${SVNREV}" > revision.h')
+    system('printf "%s" "$${LITERAL_HASH}define SVNREV $${SVNREV}" > revision.h')
 }
 
 QMAKE_CXXFLAGS_WARN_ON += -Wno-reorder


### PR DESCRIPTION
With dash as the command interpreter revision.h contains:
 -n #define SVNREV release

this causes a compilation error: stray ‘#’ in program