### PR TITLE
Refactor preferences

### DIFF
--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -516,7 +516,7 @@ void MerkaartorPreferences::initialize()
 //  Use06Api = Sets->value("osm/use06api", "true").toBool();
     Use06Api = true;
 
-    // PRoxy upgrade
+    // Proxy upgrade
     if (!g_Merk_Ignore_Preferences && !g_Merk_Reset_Preferences) {
         if (Sets->contains("proxy/Use")) {
             bool b = Sets->value("proxy/Use").toBool();

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -245,8 +245,6 @@ MerkaartorPreferences::MerkaartorPreferences()
         version = Sets->value("version/version", "0").toString();
     }
 
-    theToolList = new ToolList();
-
     connect(&httpRequest, SIGNAL(authenticationRequired(QNetworkReply*, QAuthenticator*)), this, SLOT(on_authenticationRequired(QNetworkReply*, QAuthenticator*)));
     connect(&httpRequest, SIGNAL(finished(QNetworkReply*)),this,SLOT(on_requestFinished(QNetworkReply*)));
     connect(&httpRequest, SIGNAL(sslErrors(QNetworkReply *, const QList<QSslError>&)), this, SLOT(on_sslErrors(QNetworkReply*, const QList<QSslError>&)));
@@ -267,7 +265,6 @@ MerkaartorPreferences::MerkaartorPreferences()
 
 MerkaartorPreferences::~MerkaartorPreferences()
 {
-    delete theToolList;
     delete Sets;
 #ifdef USE_LIBPROXY
     px_proxy_factory_free(proxyFactory);
@@ -573,12 +570,12 @@ void MerkaartorPreferences::initialize()
         tl = Sets->value("Tools/list").toStringList();
         for (int i=0; i<tl.size(); i+=TOOL_FIELD_SIZE) {
             Tool t(tl[i], tl[i+1]);
-            theToolList->insert(tl[i], t);
+            theToolList.insert(tl[i], t);
         }
     }
-    if (!theToolList->contains("Inkscape")) {
+    if (!theToolList.contains("Inkscape")) {
         Tool t("Inkscape", "");
-        theToolList->insert("Inkscape", t);
+        theToolList.insert("Inkscape", t);
     }
 
     QStringList Servers;
@@ -1058,16 +1055,16 @@ ExportType MerkaartorPreferences::getExportType() const
 }
 
 /* Tools */
-ToolList* MerkaartorPreferences::getTools() const
+ToolList* MerkaartorPreferences::getTools()
 {
-    return theToolList;
+    return &theToolList;
 }
 
 void MerkaartorPreferences::setTools()
 {
     if (!g_Merk_Ignore_Preferences) {
         QStringList tl;
-        ToolListIterator i(*theToolList);
+        ToolListIterator i(theToolList);
         while (i.hasNext()) {
             i.next();
             Tool t = i.value();
@@ -1082,7 +1079,7 @@ Tool MerkaartorPreferences::getTool(QString toolName) const
 {
     Tool ret;
 
-    ToolListIterator i(*theToolList);
+    ToolListIterator i(theToolList);
     while (i.hasNext()) {
         i.next();
         if (i.key() == toolName) {

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -1575,20 +1575,20 @@ void MerkaartorPreferences::saveTMSes()
 }
 
 /* Bookmarks */
-void MerkaartorPreferences::loadBookmark(QString fn)
+void MerkaartorPreferences::loadBookmarksFromFile(QString fileName)
 {
-    if (QDir::isRelativePath(fn))
-        fn = QCoreApplication::applicationDirPath() + "/" + fn;
+    if (QDir::isRelativePath(fileName))
+        fileName = QCoreApplication::applicationDirPath() + "/" + fileName;
 
-    QFile file(fn);
+    QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
-//      QMessageBox::critical(this, tr("Invalid file"), tr("%1 could not be opened.").arg(fn));
+//      QMessageBox::critical(this, tr("Invalid file"), tr("%1 could not be opened.").arg(fileName));
         return;
     }
 
     QDomDocument theXmlDoc;
     if (!theXmlDoc.setContent(&file)) {
-//		QMessageBox::critical(this, tr("Invalid file"), tr("%1 is not a valid XML file.").arg(fn));
+//		QMessageBox::critical(this, tr("Invalid file"), tr("%1 is not a valid XML file.").arg(fileName));
         file.close();
         return;
     }
@@ -1601,16 +1601,9 @@ void MerkaartorPreferences::loadBookmark(QString fn)
 
 void MerkaartorPreferences::loadBookmarks()
 {
-    QString fn;
-
-    fn = HOMEDIR + "/BookmarksList.xml";
-    loadBookmark(fn);
-
-    fn = QString(SHAREDIR) + "/BookmarksList.xml";
-    loadBookmark(fn);
-
-    fn = ":/BookmarksList.xml";
-    loadBookmark(fn);
+    loadBookmarksFromFile(HOMEDIR + "/BookmarksList.xml");
+    loadBookmarksFromFile(QString(SHAREDIR) + "/BookmarksList.xml");
+    loadBookmarksFromFile(":/BookmarksList.xml");
 }
 
 void MerkaartorPreferences::saveBookmarks()

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -217,24 +217,31 @@ Tool::Tool()
 
 /* MekaartorPreferences */
 
+namespace {
+
+QSettings* getSettings() {
+    if (!g_Merk_Portable) {
+        return new QSettings();
+    } else {
+        return new QSettings(qApp->applicationDirPath() + "/merkaartor.ini", QSettings::IniFormat);
+    }
+}
+
+}  // namespace
+
 MerkaartorPreferences::MerkaartorPreferences()
-    : Sets(0)
 {
     if (!g_Merk_Ignore_Preferences) {
-        if (!g_Merk_Portable) {
-            Sets = new QSettings();
+        Sets = getSettings();
 
-            QSettings oldSettings("BartVanhauwaert", "Merkaartor");
-            QStringList oldKeys = oldSettings.allKeys();
-            foreach(QString k, oldKeys) {
-                Sets->setValue(k, oldSettings.value(k));
-                Sets->sync();
-                oldSettings.remove(k);
-            }
-            oldSettings.clear();
-        } else {
-            Sets = new QSettings(qApp->applicationDirPath() + "/merkaartor.ini", QSettings::IniFormat);
+        QSettings oldSettings("BartVanhauwaert", "Merkaartor");
+        QStringList oldKeys = oldSettings.allKeys();
+        foreach(QString k, oldKeys) {
+            Sets->setValue(k, oldSettings.value(k));
+            Sets->sync();
+            oldSettings.remove(k);
         }
+        oldSettings.clear();
         version = Sets->value("version/version", "0").toString();
     }
 
@@ -1674,14 +1681,9 @@ void MerkaartorPreferences::saveOsmServers()
 QString getDefaultLanguage(bool returnDefault)
 {
     if (!g_Merk_Ignore_Preferences && !g_Merk_Reset_Preferences) {
-        QSettings* Sets;
-        if (!g_Merk_Portable) {
-            Sets = new QSettings();
-        } else {
-            Sets = new QSettings(qApp->applicationDirPath() + "/merkaartor.ini", QSettings::IniFormat);
-        }
-        QString lang = Sets->value("locale/language").toString();
-        delete Sets;
+        QSettings* sets = getSettings();
+        QString lang = sets->value("locale/language").toString();
+        delete sets;
         if (lang == "")
             if (returnDefault)
                 lang = QLocale::system().name().split("_")[0];
@@ -1697,12 +1699,8 @@ QString getDefaultLanguage(bool returnDefault)
 void setDefaultLanguage(const QString& theValue)
 {
     if (!g_Merk_Ignore_Preferences) {
-        QSettings* Sets;
-        if (!g_Merk_Portable) {
-            Sets = new QSettings();
-        } else {
-            Sets = new QSettings(qApp->applicationDirPath() + "/merkaartor.ini", QSettings::IniFormat);
-        }
-        Sets->setValue("locale/language", theValue);
+        QSettings* sets = getSettings();
+        sets->setValue("locale/language", theValue);
+        // TODO: 'sets' memory leak?
     }
 }

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -30,6 +30,11 @@
 #include "MasPaintStyle.h"
 
 
+// TODO: Replace 'g_Merk_Ignore_Preferences' by having two implementations
+// of the "preferences API": one that behaves as if
+// g_Merk_Ignore_Preferences == false, and one that ignores writes
+// and always returns default settings.
+
 #define M_PARAM_IMPLEMENT_BOOL(Param, Category, Default) \
     bool mb_##Param = false; \
     void MerkaartorPreferences::set##Param(bool theValue) \
@@ -290,6 +295,9 @@ void MerkaartorPreferences::save(bool UserPwdChanged)
     saveTagListFirstColumnWidth();
     Sets->sync();
 
+    // TODO: There is either some misnaming here or a bug. Why would settings
+    // be pulled from OSM only if the password changed, and pushed to OSM
+    // only otherwise?
     if (UserPwdChanged)
         fromOsmPref();
     else
@@ -319,6 +327,7 @@ void MerkaartorPreferences::toOsmPref()
     QByteArray ba = qCompress(theXmlDoc.toString().toUtf8());
     QByteArray PrefsXML = ba.toBase64();
 
+    // TODO: Why is it required to load from PrefsXML in chunk of 254?
     QStringList slicedPrefs;
     for (int i=0; i<PrefsXML.size(); i+=254) {
         QString s = PrefsXML.mid(i, 254);
@@ -581,6 +590,9 @@ void MerkaartorPreferences::initialize()
     QStringList Servers;
     if (!g_Merk_Ignore_Preferences && !g_Merk_Reset_Preferences) {
         Servers = Sets->value("WSM/servers").toStringList();
+	// TODO: Apparently WMS/servers is a list, and every 7 consecutive
+	// items describe a single server. There should be some documentation
+	// about what do the fields mean. Same with TMS/servers.
         if (Servers.size()) {
             for (int i=0; i<Servers.size(); i+=7) {
                 WmsServer S(Servers[i], Servers[i+1], Servers[i+2], Servers[i+3], Servers[i+4], Servers[i+5], Servers[i+6], "", "");

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -845,12 +845,6 @@ ProjectionItem MerkaartorPreferences::getProjection(QString aProj)
 }
 #endif
 
-void MerkaartorPreferences::setCurrentFilter(FilterType theValue)
-{
-    if (!g_Merk_Ignore_Preferences)
-        Sets->setValue("filter/Type", theValue);
-}
-
 QString MerkaartorPreferences::getCurrentFilter()
 {
     if (!g_Merk_Ignore_Preferences && !g_Merk_Reset_Preferences)

--- a/src/Preferences/MerkaartorPreferences.h
+++ b/src/Preferences/MerkaartorPreferences.h
@@ -175,11 +175,6 @@ public:
     QSettings* getQSettings() const { return Sets; }
     void save(bool UserPwdChanged = false);
 
-    void toOsmPref();
-    void fromOsmPref();
-    void putOsmPref(const QString& k, const QString& v);
-    void deleteOsmPref(const QString& k);
-
     const QVector<qreal> getParentDashes() const;
 
     //bool use06Api() const;
@@ -207,7 +202,6 @@ public:
 
     /* Visual */
     QStringList getAlphaList() const;
-    void setAlphaList();
     qreal getAlpha(QString lvl);
     QHash<QString, qreal>* getAlphaPtr();
 
@@ -233,8 +227,8 @@ public:
     M_PARAM_DECLARE_INT_DELAYED(TagListFirstColumnWidth)
 
     /* MainWindow state */
-    void saveMainWindowState(const class MainWindow * mainWindow);
-    void restoreMainWindowState(class MainWindow * mainWindow) const;
+    void saveMainWindowState(const MainWindow * mainWindow);
+    void restoreMainWindowState(MainWindow * mainWindow) const;
 
     void setInitialPosition(MapView* vw);
     void initialPosition(MapView* vw);
@@ -279,11 +273,15 @@ public:
     M_PARAM_DECLARE_INT(PolygonSides)
 
     /* Recent */
+private:
     void setRecentOpen(const QStringList & theValue);
+public:
     QStringList getRecentOpen() const;
     void addRecentOpen(const QString & theValue);
 
+private:
     void setRecentImport(const QStringList & theValue);
+public:
     QStringList getRecentImport() const;
     void addRecentImport(const QString & theValue);
 
@@ -400,10 +398,6 @@ public:
     IMapAdapterFactory* getBackgroundPlugin(const QUuid& anAdapterUid);
     QMap<QUuid, IMapAdapterFactory *> getBackgroundPlugins();
 
-    /* Projections */
-    void loadProjection(QString fn);
-    void loadProjections();
-    void saveProjections();
 #ifndef _MOBILE
     void setProjectionType(QString theValue);
     QString getProjectionType();
@@ -411,14 +405,23 @@ public:
     ProjectionItem getProjection(QString aProj);
 #endif
 
-    /* Filters */
-    void loadFilter(QString fn);
-    void loadFilters();
-    void saveFilters();
-    void setCurrentFilter(FilterType theValue);
     FilterType getCurrentFilter();
     FiltersList* getFiltersList();
     FilterItem getFilter(QString aFilter);
+
+    BookmarkList*  getBookmarks();
+    WmsServerList* getWmsServers();
+    TmsServerList* getTmsServers();
+    OsmServerList* getOsmServers();
+
+    M_PARAM_DECLARE_STRING(SelectedServer);
+
+private:
+    void fromOsmPref();
+    void toOsmPref();
+    void putOsmPref(const QString& k, const QString& v);
+    void deleteOsmPref(const QString& k);
+    void setAlphaList();
 
     /* WMSes */
     void loadWMS(QString fn);
@@ -439,24 +442,20 @@ public:
     void loadOsmServers();
     void saveOsmServers();
 
-    BookmarkList*  getBookmarks();
-    WmsServerList* getWmsServers();
-    TmsServerList* getTmsServers();
-    OsmServerList* getOsmServers();
+    /* Filters */
+    void loadFilter(QString fn);
+    void loadFilters();
+    void saveFilters();
 
-    M_PARAM_DECLARE_STRING(SelectedServer);
+    /* Projections */
+    void loadProjection(QString fn);
+    void loadProjections();
+    void saveProjections();
 
-private:
     QVector<qreal> parentDashes;
 
     bool Use06Api;
     QString version;
-    bool RightSideDriving;
-    qreal DoubleRoadDistance;
-    QString WorkingDir;
-    QString OsmWebsite;
-    QString OsmUser;
-    QString OsmPassword;
 
     QNetworkAccessManager httpRequest;
     QNetworkReply *OsmPrefLoadReply;
@@ -470,7 +469,6 @@ private:
     QHash<QString, qreal> alpha;
     ToolList theToolList;
     QSettings * Sets;
-    QStringList projTypes;
     QMap<QUuid, IMapAdapterFactory *> mBackgroundPlugins;
     ProjectionsList theProjectionsList;
     FiltersList theFiltersList;
@@ -488,9 +486,9 @@ private:
     static IPaintStyle* m_EPSInstance;
 
 private slots:
-	void on_requestFinished ( QNetworkReply *reply );
-	void on_authenticationRequired( QNetworkReply *reply, QAuthenticator *auth );
-	void on_sslErrors(QNetworkReply *reply, const QList<QSslError>& errors);
+    void on_requestFinished ( QNetworkReply *reply );
+    void on_authenticationRequired( QNetworkReply *reply, QAuthenticator *auth );
+    void on_sslErrors(QNetworkReply *reply, const QList<QSslError>& errors);
 
 signals:
     void bookmarkChanged();

--- a/src/Preferences/MerkaartorPreferences.h
+++ b/src/Preferences/MerkaartorPreferences.h
@@ -268,7 +268,9 @@ public:
     ExportType getExportType() const;
 
     /* Tools */
-    ToolList* getTools() const;
+    // TODO: Returning ToolList* here is very promiscuous.
+    // 'getTools()' should probably return 'const ToolList&' instead.
+    ToolList* getTools();
     Tool getTool(QString toolName) const;
 
     QStringList getShortcuts() const;
@@ -466,7 +468,7 @@ private:
     void initialize();
 
     QHash<QString, qreal> alpha;
-    ToolList* theToolList;
+    ToolList theToolList;
     QSettings * Sets;
     QStringList projTypes;
     QMap<QUuid, IMapAdapterFactory *> mBackgroundPlugins;

--- a/src/Preferences/MerkaartorPreferences.h
+++ b/src/Preferences/MerkaartorPreferences.h
@@ -434,7 +434,7 @@ private:
     void saveTMSes();
 
     /* Bookmarks */
-    void loadBookmark(QString fn);
+    void loadBookmarksFromFile(QString fileName);
     void loadBookmarks();
     void saveBookmarks();
 

--- a/src/Preferences/MerkaartorPreferences.h
+++ b/src/Preferences/MerkaartorPreferences.h
@@ -424,12 +424,12 @@ private:
     void setAlphaList();
 
     /* WMSes */
-    void loadWMS(QString fn);
+    void loadWMSesFromFile(QString fileName);
     void loadWMSes();
     void saveWMSes();
 
     /* TMSes */
-    void loadTMS(QString fn);
+    void loadTMSesFromFile(QString fileName);
     void loadTMSes();
     void saveTMSes();
 
@@ -443,12 +443,12 @@ private:
     void saveOsmServers();
 
     /* Filters */
-    void loadFilter(QString fn);
+    void loadFiltersFromFile(QString fileName);
     void loadFilters();
     void saveFilters();
 
     /* Projections */
-    void loadProjection(QString fn);
+    void loadProjectionsFromFile(QString fileName);
     void loadProjections();
     void saveProjections();
 
@@ -457,11 +457,12 @@ private:
     bool Use06Api;
     QString version;
 
+    // TODO: These network objects shouldn't be shared between methods
+    // of MerkaartorPreferences.
     QNetworkAccessManager httpRequest;
     QNetworkReply *OsmPrefLoadReply;
     QNetworkReply *OsmPrefSaveReply;
     QNetworkReply *OsmPrefDeleteReply;
-    QMap<QString, int> OsmPrefListsCount;
 
     void setTools();
     void initialize();


### PR DESCRIPTION
* Move everything possible to private. Remove unused private methods and fields. (Some of these apparently duplicated fields created by macros.)
* Factor together a fragment generating a `QSettings` instance in ~3 places.
* Keep theToolList as an instance instead of a pointer
* Many preferences are loaded XML files, which can be in several possible filesystem paths. The pattern of getting these paths was repeated slightly differently in ~4 places. This merges 2 of them and adds TODOs to figure out why do the directory paths differ elsewhere.
* Additionally, these preferences were loaded in methods names `loadXyzzys`, which would call `loadXyzzy("/filename1"), loadXyzzy("/filename2"), ...`. This is confusing, since each `/filename1, /filename2, ...` may contain multiple `Xyzzys`. I renamed all instances of `loadXyzzy` to `loadXyzzysFromFile`.
* Comments about various encountered issues.