### PR TITLE
Move single file importing into separate method

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1621,6 +1621,120 @@ static bool mayDiscardStyleChanges(QWidget* aWidget)
                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No;
 }
 
+MainWindow::ImportStatus MainWindow::importFile(Document * mapDocument, const QString& fileName, Layer*& newLayer) {
+    QString baseFileName = fileName.section('/', - 1);
+    if (fileName.toLower().endsWith(".gpx")) {
+        QList<TrackLayer*> theTracklayers;
+        newLayer = new TrackLayer( baseFileName + " - " + tr("Waypoints"), baseFileName);
+        mapDocument->add(newLayer);
+        theTracklayers.append((TrackLayer*) newLayer);
+        bool importOK = importGPX(this, baseFileName, mapDocument, theTracklayers);
+        if (!importOK) {
+            for (int i=0; i<theTracklayers.size(); i++) {
+                mapDocument->remove(theTracklayers[i]);
+                delete theTracklayers[i];
+            }
+        } else {
+            if (!newLayer->size()) {
+                mapDocument->remove(newLayer);
+                delete newLayer;
+            }
+            for (int i=1; i<theTracklayers.size(); i++) {
+                if (theTracklayers[i]->name().isEmpty())
+                    theTracklayers[i]->setName(QString(baseFileName + " - " + tr("Track %1").arg(i)));
+                if (importOK && M_PREFS->getAutoExtractTracks()) {
+                    theTracklayers[i]->extractLayer();
+                }
+            }
+        }
+	return importOK ? IMPORT_OK : IMPORT_ERROR;
+    }
+    else if (fileName.toLower().endsWith(".osm")) {
+        newLayer = new DrawingLayer( baseFileName );
+        mapDocument->add(newLayer);
+        return importOSM(this, baseFileName, mapDocument, newLayer) ? IMPORT_OK : IMPORT_ERROR;
+    }
+#ifndef FRISIUS_BUILD
+    else if (fileName.toLower().endsWith(".osc")) {
+        if (g_Merk_Frisius) {
+            newLayer = new DrawingLayer( baseFileName );
+            mapDocument->add(newLayer);
+        } else {
+            newLayer = mapDocument->getDirtyOrOriginLayer();
+        }
+        return mapDocument->importOSC(fileName, (DrawingLayer*)newLayer) ? IMPORT_OK : IMPORT_ERROR;
+    }
+#endif
+    else if (fileName.toLower().endsWith(".ngt")) {
+        newLayer = new TrackLayer( baseFileName );
+        newLayer->setUploadable(false);
+        mapDocument->add(newLayer);
+        bool importOK = importNGT(this, baseFileName, mapDocument, newLayer);
+        if (importOK && M_PREFS->getAutoExtractTracks()) {
+            ((TrackLayer *)newLayer)->extractLayer();
+        }
+        return importOK ? IMPORT_OK : IMPORT_ERROR;
+    }
+    else if (fileName.toLower().endsWith(".nmea") || (fileName.toLower().endsWith(".nma"))) {
+        newLayer = new TrackLayer( baseFileName );
+        newLayer->setUploadable(false);
+        mapDocument->add(newLayer);
+        bool importOK = mapDocument->importNMEA(baseFileName, (TrackLayer *)newLayer);
+        if (importOK && M_PREFS->getAutoExtractTracks()) {
+            ((TrackLayer *)newLayer)->extractLayer();
+        }
+        return importOK ? IMPORT_OK : IMPORT_ERROR;
+    }
+    else if (fileName.toLower().endsWith(".kml")) {
+        if (QMessageBox::warning(this, MainWindow::tr("Big Fat Copyright Warning"),
+                 MainWindow::tr(
+                 "You are trying to import a KML file. Please be aware that:\n"
+                 "\n"
+                 " - You cannot import to OSM a KML file created from Google Earth. While you might\n"
+                 "   think that nodes you created from GE are yours, they are not!\n"
+                 "   They are still a derivative work from GE, and, as such, cannot be used in OSM.\n"
+                 "\n"
+                 " - If you downloaded it from the Internet, chances are that there is a copyright on it.\n"
+                 "   Please be absolutely sure that using those data in OSM is permitted by the author, or\n"
+                 "   that the data is public domain.\n"
+                 "\n"
+                 "If unsure, please seek advice on the \"legal\" or \"talk\" openstreetmap mailing lists.\n"
+                 "\n"
+                 "Are you absolutely sure this KML can legally be imported in OSM?"),
+                 QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
+        {
+            newLayer = new DrawingLayer( baseFileName );
+            newLayer->setUploadable(false);
+            mapDocument->add(newLayer);
+            return mapDocument->importKML(baseFileName, (TrackLayer *)newLayer) ? IMPORT_OK : IMPORT_ERROR;
+        } else
+            return IMPORT_ABORTED;
+    }
+    else if (fileName.toLower().endsWith(".csv")) {
+#ifndef Q_OS_SYMBIAN
+        QApplication::restoreOverrideCursor();
+#endif
+        newLayer = new DrawingLayer( baseFileName );
+        newLayer->setUploadable(false);
+        mapDocument->add(newLayer);
+        return mapDocument->importCSV(baseFileName, (DrawingLayer*)newLayer) ? IMPORT_OK : IMPORT_ERROR;
+    }
+#ifdef USE_PROTOBUF
+    else if (fileName.toLower().endsWith(".pbf")) {
+        newLayer = new DrawingLayer( baseFileName );
+        mapDocument->add(newLayer);
+        return mapDocument->importPBF(baseFileName, (DrawingLayer*)newLayer) ? IMPORT_OK : IMPORT_ERROR;
+    }
+#endif
+    else { // Fallback to GDAL
+        qDebug() << "Trying GDAL";
+        newLayer = new DrawingLayer( baseFileName );
+        newLayer->setUploadable(false);
+        mapDocument->add(newLayer);
+        return mapDocument->importGDAL(baseFileName, (DrawingLayer*)newLayer) ? IMPORT_OK : IMPORT_ERROR;
+    }
+}
+
 bool MainWindow::importFiles(Document * mapDocument, const QStringList & fileNames, QStringList * importedFileNames )
 {
     createProgressDialog();
@@ -1634,139 +1748,32 @@ bool MainWindow::importFiles(Document * mapDocument, const QStringList & fileNam
     while (it.hasNext())
     {
         const QString & fn = it.next();
-        changeCurrentDirToFile(fn);
+        changeCurrentDirToFile(fn);  // TODO: Whyyyyy?!
 
-        QString baseFileName = fn.section('/', - 1);
         Layer* newLayer = NULL;
+	// TODO: The passing mechanism of newLayer is evil black magic.
+	ImportStatus fileImportResult = importFile(mapDocument, fn, newLayer);
 
-        bool importOK = false;
-        bool importAborted = false;
-
-        if (fn.toLower().endsWith(".gpx")) {
-            QList<TrackLayer*> theTracklayers;
-            TrackLayer* newLayer = new TrackLayer( baseFileName + " - " + tr("Waypoints"), baseFileName);
-            mapDocument->add(newLayer);
-            theTracklayers.append(newLayer);
-            importOK = importGPX(this, baseFileName, mapDocument, theTracklayers);
-            if (!importOK) {
-                for (int i=0; i<theTracklayers.size(); i++) {
-                    mapDocument->remove(theTracklayers[i]);
-                    delete theTracklayers[i];
-                }
-            } else {
-                if (!newLayer->size()) {
-                    mapDocument->remove(newLayer);
-                    delete newLayer;
-                }
-                for (int i=1; i<theTracklayers.size(); i++) {
-                    if (theTracklayers[i]->name().isEmpty())
-                        theTracklayers[i]->setName(QString(baseFileName + " - " + tr("Track %1").arg(i)));
-                    if (importOK && M_PREFS->getAutoExtractTracks()) {
-                        theTracklayers[i]->extractLayer();
-                    }
-                }
-            }
-        }
-        else if (fn.toLower().endsWith(".osm")) {
-            newLayer = new DrawingLayer( baseFileName );
-            mapDocument->add(newLayer);
-            importOK = importOSM(this, baseFileName, mapDocument, newLayer);
-        }
-#ifndef FRISIUS_BUILD
-        else if (fn.toLower().endsWith(".osc")) {
-            if (g_Merk_Frisius) {
-                newLayer = new DrawingLayer( baseFileName );
-                mapDocument->add(newLayer);
-            } else {
-                newLayer = mapDocument->getDirtyOrOriginLayer();
-            }
-            importOK = mapDocument->importOSC(fn, (DrawingLayer*)newLayer);
-        }
-#endif
-        else if (fn.toLower().endsWith(".ngt")) {
-            newLayer = new TrackLayer( baseFileName );
-            newLayer->setUploadable(false);
-            mapDocument->add(newLayer);
-            importOK = importNGT(this, baseFileName, mapDocument, newLayer);
-            if (importOK && M_PREFS->getAutoExtractTracks()) {
-                ((TrackLayer *)newLayer)->extractLayer();
-            }
-        }
-        else if (fn.toLower().endsWith(".nmea") || (fn.toLower().endsWith(".nma"))) {
-            newLayer = new TrackLayer( baseFileName );
-            newLayer->setUploadable(false);
-            mapDocument->add(newLayer);
-            importOK = mapDocument->importNMEA(baseFileName, (TrackLayer *)newLayer);
-            if (importOK && M_PREFS->getAutoExtractTracks()) {
-                ((TrackLayer *)newLayer)->extractLayer();
-            }
-        }
-        else if (fn.toLower().endsWith(".kml")) {
-            if (QMessageBox::warning(this, MainWindow::tr("Big Fat Copyright Warning"),
-                     MainWindow::tr(
-                     "You are trying to import a KML file. Please be aware that:\n"
-                     "\n"
-                     " - You cannot import to OSM a KML file created from Google Earth. While you might\n"
-                     "   think that nodes you created from GE are yours, they are not!\n"
-                     "   They are still a derivative work from GE, and, as such, cannot be used in OSM.\n"
-                     "\n"
-                     " - If you downloaded it from the Internet, chances are that there is a copyright on it.\n"
-                     "   Please be absolutely sure that using those data in OSM is permitted by the author, or\n"
-                     "   that the data is public domain.\n"
-                     "\n"
-                     "If unsure, please seek advice on the \"legal\" or \"talk\" openstreetmap mailing lists.\n"
-                     "\n"
-                     "Are you absolutely sure this KML can legally be imported in OSM?"),
-                     QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
-            {
-                newLayer = new DrawingLayer( baseFileName );
-                newLayer->setUploadable(false);
-                mapDocument->add(newLayer);
-                importOK = mapDocument->importKML(baseFileName, (TrackLayer *)newLayer);
-            } else
-                importAborted = true;
-        }
-        else if (fn.toLower().endsWith(".csv")) {
-#ifndef Q_OS_SYMBIAN
-            QApplication::restoreOverrideCursor();
-#endif
-            newLayer = new DrawingLayer( baseFileName );
-            newLayer->setUploadable(false);
-            mapDocument->add(newLayer);
-            importOK = mapDocument->importCSV(baseFileName, (DrawingLayer*)newLayer);
-        }
-#ifdef USE_PROTOBUF
-        else if (fn.toLower().endsWith(".pbf")) {
-            newLayer = new DrawingLayer( baseFileName );
-            mapDocument->add(newLayer);
-            importOK = mapDocument->importPBF(baseFileName, (DrawingLayer*)newLayer);
-        }
-#endif
-        else { // Fallback to GDAL
-            qDebug() << "Trying GDAL";
-            newLayer = new DrawingLayer( baseFileName );
-            newLayer->setUploadable(false);
-            mapDocument->add(newLayer);
-            importOK = mapDocument->importGDAL(baseFileName, (DrawingLayer*)newLayer);
-        }
-
-        if (!importOK && newLayer)
+	// TODO: Cleaning up after an unsuccessful import should be done
+	// in importFile.
+        if (fileImportResult != IMPORT_OK && newLayer)
             mapDocument->remove(newLayer);
 
-        if (importOK)
-        {
-            foundImport = true;
+	switch (fileImportResult) {
+	    case IMPORT_OK:
+                foundImport = true;
 
-            if (importedFileNames)
-                importedFileNames->append(fn);
+                if (importedFileNames)
+                    importedFileNames->append(fn);
 
-            emit content_changed();
-        }
-        else
-        if (!importAborted)
-        {
-            delete newLayer;
-            QMessageBox::warning(this, tr("No valid file"), tr("%1 could not be opened.").arg(fn));
+                emit content_changed();
+		break;
+	    case IMPORT_ERROR:
+                delete newLayer;
+                QMessageBox::warning(this, tr("No valid file"), tr("%1 could not be opened.").arg(fn));
+	    case IMPORT_ABORTED:
+		// noop
+		break;
         }
     }
 #ifndef Q_OS_SYMBIAN

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -278,6 +278,7 @@ public:
     void syncOSM(const QString &aWeb, const QString &aUser, const QString &aPwd);
 
     void launchInteraction(Interaction *anInteraction);
+    enum ImportStatus { IMPORT_OK, IMPORT_ABORTED, IMPORT_ERROR };
 
 protected:
     MapView* theView;
@@ -310,6 +311,7 @@ private slots:
     void on_viewWireframeAction_toggled(bool arg1);
 
 private:
+    ImportStatus importFile(Document* mapDocument, const QString& fileName, Layer*& newLayer);
     void updateMenu();
     void updateRecentOpenMenu();
     void updateRecentImportMenu();


### PR DESCRIPTION
This only moves all the file importing stuff to the left a tab or two, but it makes importFiles much easier to follow.