### PR TITLE
Fix desktop file syntax for Keywords list

### DIFF
--- a/src/merkaartor.desktop
+++ b/src/merkaartor.desktop
@@ -10,4 +10,4 @@ Exec=merkaartor
 Terminal=false
 StartupNotify=false
 Categories=Education;Geography;Network;Qt;
-Keywords=OSM;GIS;Map;Geo
+Keywords=OSM;GIS;Map;Geo;


### PR DESCRIPTION
The `desktop-file-validate` utility reported this error:
```
src/merkaartor.desktop: hint: value "Education;Geography;Network;Qt;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
src/merkaartor.desktop: error: value "OSM;GIS;Map;Geo" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```