### PR TITLE
Fix 'commited' typo, replace with 'committed'.

### DIFF
--- a/src/Sync/SyncListDialog.ui
+++ b/src/Sync/SyncListDialog.ui
@@ -56,7 +56,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>The following changes will be commited:</string>
+      <string>The following changes will be committed:</string>
      </property>
     </widget>
    </item>

--- a/translations/README.md
+++ b/translations/README.md
@@ -13,7 +13,7 @@ The regular workflow is:
    This pushes the original english strings to Transifex, updating the database and
    allowing new strings to be downloaded.
 
-1) Before release, Transifex data should be pulled and commited into the
+1) Before release, Transifex data should be pulled and committed into the
 repository. This is not necessary, but serves as a backup in case something
 terrible happens to Transifex.
 


### PR DESCRIPTION
The lintian QA tool reported the spelling error for the Debian package build of 0.18.3-rc1