### PR TITLE
Specify proto2 syntax to fix warnings with protobuf 3.0.0.

### DIFF
--- a/src/ImportExport/fileformat.proto
+++ b/src/ImportExport/fileformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;

--- a/src/ImportExport/osmformat.proto
+++ b/src/ImportExport/osmformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "crosby.binary";
 package OSMPBF;


### PR DESCRIPTION
This fixes warnings with `protoc` from protobuf 3.0.0:
```
protoc --proto_path=. --cpp_out=. fileformat.proto
protoc --proto_path=. --cpp_out=. osmformat.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: osmformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: fileformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```
This change has also been forwarded to osmpbf (https://github.com/scrosby/OSM-binary/pull/29) & osmosis (https://github.com/openstreetmap/osmosis/pull/33).