### PR TITLE
Lock Way while QPainterPath is used outside of Way

### DIFF
--- a/src/Features/Feature.cpp
+++ b/src/Features/Feature.cpp
@@ -1091,3 +1091,13 @@ QString Feature::toMainHtml(QString type, QString systemtype)
 
     return S;
 }
+
+void Feature::getLock()
+{
+	featMutex.lock();
+}
+
+void Feature::releaseLock()
+{
+	featMutex.unlock();
+}

--- a/src/Features/Feature.h
+++ b/src/Features/Feature.h
@@ -336,6 +336,9 @@ public:
 
     static QString stripToOSMId(const IFeature::FId& id);
 
+    void getLock();
+    void releaseLock();
+
 public:
 #ifdef USE_SPATIALITE
     quint32 internal_id;

--- a/src/Render/MapRenderer.cpp
+++ b/src/Render/MapRenderer.cpp
@@ -44,7 +44,9 @@ void BackgroundStyleLayer::draw(Way* R)
         }
 
         r->thePainter->setPen(thePen);
+        R->getLock();
         r->thePainter->drawPath(r->theTransform.map(R->getPath()));
+        R->releaseLock();
     }
 }
 


### PR DESCRIPTION
Moving node crashes Merkaartor as QPainterPath is accessed outside of Way while Way is modifying it in different thread. Fix that works for me.