### PR TITLE
FIX: HTTP Header: use numeric portnumber for Host

### DIFF
--- a/src/Sync/DownloadOSM.cpp
+++ b/src/Sync/DownloadOSM.cpp
@@ -252,7 +252,7 @@ bool Downloader::request(const QString& Method, const QUrl& url, const QString& 
 
     QString sReq = url.toString(QUrl::RemoveScheme | QUrl::RemoveAuthority);
     QHttpRequestHeader Header(Method,sReq);
-    Header.setValue("Host",url.host()+':'+url.port(80));
+    Header.setValue("Host",url.host()+':'+QString::number(url.port(80)));
     Header.setValue("User-Agent", USER_AGENT);
 
     QString auth = QString("%1:%2").arg(User).arg(Password);


### PR DESCRIPTION
This patch fixes an issue on a really ancient Merkaartor release - namely an incorrect HTTP Header field "Host". For years this was not an issue, but due to recent changes on the Apache configuration, the Hostname is now checked on the server and a HTTP 301 redirect returned. The old Merkaartor version however has no way to deal with this situation and has become more or less useless.

Please see https://github.com/openstreetmap/openstreetmap-website/issues/1407 for details.

I don't know, if it makes sense to release a 0.17.3 for Windows - that would be needed for users unable to migrate to 0.18. Please don't ask me why they can't upgrade, I asked the user but didn't get a conclusive answer.
