### PR TITLE
These macros are not used

### DIFF
--- a/src/common/MapView.cpp
+++ b/src/common/MapView.cpp
@@ -443,9 +443,6 @@ void floodFill(QImage& theImage, const QPoint& P, const QRgb& targetColor, const
     }
 }
 
-#define PARALLEL_LINES_NUM 5
-#define MEDIAN_LINES_NUM 5
-
 void MapView::drawLatLonGrid(QPainter & P)
 {
     if (!TEST_RFLAGS(RendererOptions::LatLonGridVisible))


### PR DESCRIPTION
My goal is to improve the ability of Merkaartor to produce printable maps.

I am working on the grid feature of a map.

Looking at MapView::drawLatLonGrid(QPainter & P), it is my view that the macros deleted in this request are not (or no longer) used.

See commit 61bf658e218d6ff192024a1ddd295a8795233345 .