### PR TITLE
Don't dereference null pointer when download fails

### DIFF
--- a/src/Sync/DownloadOSM.cpp
+++ b/src/Sync/DownloadOSM.cpp
@@ -301,7 +301,8 @@ bool downloadOSM(QWidget* aParent, const QUrl& theUrl, const QString& aUser, con
     if (!Rcv.go(theUrl))
     {
 #ifndef _MOBILE
-        aParent->setCursor(QCursor(Qt::ArrowCursor));
+        if (aParent)
+            aParent->setCursor(QCursor(Qt::ArrowCursor));
 #endif
         return false;
     }


### PR DESCRIPTION
aParent is used to update progress bar etc. but progress bar is not shown when downloading features for OSC-file.