### PR TITLE
handle the situation where object to load does not exist.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1925,13 +1925,15 @@ void MainWindow::loadUrl(const QUrl& theUrl)
             F = theDocument->getFeature(mId);
         }
         /* The feature is on our map, just select it. */
-        if (theView) {
+        if (F) { /* If F existed, e.g., was not deleted*/
+          if (theView) {
             theView->setViewport(F->boundingBox(), theView->rect());
             on_fileDownloadMoreAction_triggered();
+          }
+          properties()->setSelection(0);
+          properties()->addSelection(F);
+          emit content_changed();
         }
-        properties()->setSelection(0);
-        properties()->addSelection(F);
-        emit content_changed();
     } else if (theUrl.path() == "/add_node") {
         qreal lat = theQuery.queryItemValue("lat").toDouble();
         qreal lon = theQuery.queryItemValue("lon").toDouble();


### PR DESCRIPTION
It could have been deleted.

Osmose kept crashing when I loaded objects from Osmose, that I had already fixed by deleting.