### PR TITLE
Fix Mac build on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ deploy:
     skip_cleanup: true
     on:
         branch:
+            - ci-fixes
             - travis-ci
             - master
         condition: $TRAVIS_OS_NAME = osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
     - if [ "${TRAVIS_OS_NAME}" = "osx" ];   then ./ci/travis-osx-script.sh;   fi
 
 deploy:
+    skip_cleanup: true
     on:
         branch:
             - travis-ci

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -7,9 +7,5 @@ sudo echo "deb http://archive.ubuntu.com/ubuntu trusty main universe restricted 
 sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa
 sudo apt-add-repository -y ppa:beineri/opt-qt591-trusty
 sudo apt-get update -qq
-sudo apt-cache search qt
-sudo apt-get -qq install gdb libgdal-dev libproj-dev
-#sudo apt-get -qq install qt56xml qt56network qt56gui qt56svg qt56webengine qt56quick qt57declarative qt57tools qtbase56-dev qt56-qmake qtchooser
-sudo apt-cache search qt59
-sudo apt-get -y install qt59-meta-full
+sudo apt-get -y install gdb libgdal-dev libproj-dev qt59-meta-minimal qt59svg build-essential libgl1-mesa-dev
 qtchooser -list-versions

--- a/ci/travis-linux-script.sh
+++ b/ci/travis-linux-script.sh
@@ -6,4 +6,4 @@ set -ev
 
 #qtchooser -qt=qt$QT -run-tool=qmake
 qmake
-make
+make -j3

--- a/ci/travis-osx-script.sh
+++ b/ci/travis-osx-script.sh
@@ -5,7 +5,7 @@ set -ev
 git tag
 QMAKE=`find /usr/local -name "qmake" | head -n 1`
 $QMAKE SPATIALITE=0
-make
+make -j3
 lrelease src/src.pro
 
 find ./binaries


### PR DESCRIPTION
Skip cleanup on travis builds.

By default, travis clean up the working directory including artifacts.
That makes sense for some workflows, but we need the binaries present
for upload.