### PR TITLE
add source tag to changeset by default

### DIFF
--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -1253,7 +1253,7 @@ M_PARAM_IMPLEMENT_INT_DELAYED(TagListFirstColumnWidth, visual, 20)
 M_PARAM_IMPLEMENT_BOOL(TranslateTags, locale, true)
 
 /* Background */
-M_PARAM_IMPLEMENT_BOOL(AutoSourceTag, backgroundImage, true)
+M_PARAM_IMPLEMENT_BOOL(AutoSourceTag, backgroundImage, false)
 
 /* Data */
 M_PARAM_IMPLEMENT_STRING(MapdustUrl, data, "http://www.mapdust.com/feed?lang=en&ft=wrong_turn,bad_routing,oneway_road,blocked_street,missing_street,wrong_roundabout,missing_speedlimit,other&fd=1&minR=&maxR=")

--- a/src/Sync/DirtyListExecutorOSC.cpp
+++ b/src/Sync/DirtyListExecutorOSC.cpp
@@ -184,14 +184,21 @@ bool DirtyListExecutorOSC::start()
     Progress->setLabelText(tr("OPEN changeset"));
     QEventLoop L; L.processEvents(QEventLoop::ExcludeUserInputEvents);
 
+    QStringList sl = theDocument->getCurrentSourceTags();
+
     QString DataIn(
         "<osm>"
         "<changeset>"
         "<tag k=\"created_by\" v=\"Merkaartor %1 (%2)\"/>"
-        "<tag k=\"comment\" v=\"%3\"/>"
+        "<tag k=\"comment\" v=\"%3\"/>%4"
         "</changeset>"
         "</osm>");
-    DataIn = DataIn.arg(STRINGIFY(VERSION)).arg(QLocale::system().name().split("_")[0]).arg(Utils::encodeAttributes(glbChangeSetComment));
+    DataIn = DataIn
+        .arg(STRINGIFY(VERSION))
+        .arg(QLocale::system().name().split("_")[0])
+        .arg(Utils::encodeAttributes(glbChangeSetComment))
+        .arg((sl.size() ? "<tag k=\"source\" v=\""+ Utils::encodeAttributes(sl.join(";")) +"\"/>" : ""));
+
     QString DataOut;
     QString URL = theDownloader->getURLToOpenChangeSet();
     if (sendRequest("PUT",URL,DataIn, DataOut) != 200)


### PR DESCRIPTION
This pull request partially addresses #111, #10 and accomplishes the following:

  - Sets autoSourceTag to false by default;
  - Add source to changeset by default, see [source](https://wiki.openstreetmap.org/wiki/Key:source).

It's known that source property on tags is a bad practice nowadays. because of it I tried to remove autoSourceTag property and source tag button at properties dock.

But I failed because this mess with localizations, how do I remove "dead code" and update localizations?

