### PR TITLE
Workaround for situations when GPSD is not available.

### DIFF
--- a/src/GPS/qgpsdevice.h
+++ b/src/GPS/qgpsdevice.h
@@ -288,6 +288,8 @@ private:
     struct gps_data_t* gpsdata;
     QByteArray Buffer;
 
+    bool serverOk = true;
+
     friend class GPSSlotForwarder;
 };
 #else /*USE_GPSD_LIB*/


### PR DESCRIPTION
Fixes two problems:
- Crash when gpsd is not running at all (issue #166)
- 100% CPU usage when the gpsd is terminated unexpectedly (or not
available at all).