### PR TITLE
Generate and upload AppImage

### DIFF
--- a/ci/travis-linux-script.sh
+++ b/ci/travis-linux-script.sh
@@ -5,5 +5,15 @@ source /opt/qt59/bin/qt59-env.sh
 set -ev
 
 #qtchooser -qt=qt$QT -run-tool=qmake
-qmake
-make -j3
+qmake CONFIG+=release PREFIX=/usr
+make -j$(nproc)
+make INSTALL_ROOT=appdir -j$(nproc) install ; find src/appdir/
+wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+( cd src ; ../linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage)
+find src/appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+# curl --upload-file src/Merkaartor*.AppImage https://transfer.sh/Merkaartor-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+bash upload.sh src/Merkaartor*.AppImage*


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.