### PR TITLE
Include <exiv2/exiv2.hpp> rather than individual headers.

### DIFF
--- a/src/Docks/GeoImageDock.h
+++ b/src/Docks/GeoImageDock.h
@@ -7,8 +7,7 @@
 #include <QDockWidget>
 #include <QMouseEvent>
 #include <QShortcut>
-#include <exiv2/image.hpp>
-#include <exiv2/exif.hpp>
+#include <exiv2/exiv2.hpp>
 #include <QDrag>
 
 class ImageView;


### PR DESCRIPTION
Recent versions of exiv2 have trimmed transient inclusion, so including
the old headers didn't pull in some of the definitions that merkaartor
uses (e.g. Exiv2::Error).