### PR TITLE
Fix two problems with OsmLink

### DIFF
--- a/src/Utils/OsmLink.cpp
+++ b/src/Utils/OsmLink.cpp
@@ -37,7 +37,7 @@ QString OsmLink::parseUrl(QUrl theUrl)
 
     if (!theUrl.isValid()) return QString("Invalid URL: %1").arg(theUrl.toString());;
 
-    if (theUrl.toString().contains("openstreetmap.org/#map=")) {
+    if (theUrl.toString().contains("openstreetmap.org/") && theUrl.toString().contains("#map=")) {
         // first is 'map', zoom, lat and lon follows
         QStringList list = theUrl.fragment().split(QRegExp("[/=]"));
         qreal zoom = list[1].toInt(&parseOk);   ARG_VALID(zoom);

--- a/src/Utils/OsmLink.cpp
+++ b/src/Utils/OsmLink.cpp
@@ -39,7 +39,10 @@ QString OsmLink::parseUrl(QUrl theUrl)
 
     if (theUrl.toString().contains("openstreetmap.org/") && theUrl.toString().contains("#map=")) {
         // first is 'map', zoom, lat and lon follows
-        QStringList list = theUrl.fragment().split(QRegExp("[/=]"));
+        // afterwards, optionally &layers= may follow
+        QStringList list = theUrl.fragment().split(QRegExp("[/=&]"));
+        if(list[0] != "map")
+            return QString("Unexpected fragment parameter %1").arg(list[0]);
         qreal zoom = list[1].toInt(&parseOk);   ARG_VALID(zoom);
         qreal lat = list[2].toDouble(&parseOk); ARG_VALID(lat);
         qreal lon = list[3].toDouble(&parseOk); ARG_VALID(lon);


### PR DESCRIPTION
Previously URLs like
https://www.openstreetmap.org/way/364178985#map=17/39.25065/23.18204
or
https://www.openstreetmap.org/#map=17/39.25081/23.18021&layers=HNDG
wouldn't open, but with this PR, they can!