### PR TITLE
Fix build with GDAL 3.0

### DIFF
--- a/src/ImportExport/ImportExportGdal.h
+++ b/src/ImportExport/ImportExportGdal.h
@@ -19,7 +19,7 @@
 #include <gdal_priv.h>
 #include <gdal_version.h>
 
-#if GDAL_VERSION_MAJOR == 2
+#if GDAL_VERSION_MAJOR >= 2
 #define GDAL2
 #endif
 


### PR DESCRIPTION
The only breaking changes that could affect this project with GDAL 3.0 from what I could find are

> * OSRImportFromEPSG() takes into account official axis order.
      Traditional GIS-friendly axis order can be restored with
      OGRSpatialReference::SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
>  * Same for SetWellKnownGeogCS("WGS84") / SetFromUserInput("WGS84")

I'm not sure to what extent it affects merkaartor though.

Fixes #179 