### PR TITLE
Issue 181: downloaded gps tracks display is broken

### DIFF
--- a/src/ImportExport/ImportGPX.h
+++ b/src/ImportExport/ImportGPX.h
@@ -2,6 +2,8 @@
 #define MERKATOR_IMPORTGPX_H_
 
 #include <QList>
+#include <QObject>
+#include <QFlags>
 
 class Document;
 class TrackLayer;
@@ -10,8 +12,21 @@ class QByteArray;
 class QString;
 class QWidget;
 
-bool importGPX(QWidget* aParent, const QString& aFilename, Document* theDocument, QList<TrackLayer*>& theTracklayers);
-bool importGPX(QWidget* aParent, QByteArray& aFile, Document* theDocument, QList<TrackLayer*>& theTracklayers, bool MakeSegment);
+class ImportGPX : public QObject {
+    Q_OBJECT
+    public:
+    enum class Option {
+        NoOptions = 0x0,
+        MakeSegmented = 0x1,
+        DetectAnonymizedSegments = 0x2,
+    };
+    Q_DECLARE_FLAGS(Options,Option)
+
+    static bool import(QWidget* aParent, const QString& aFilename, Document* theDocument, QList<TrackLayer*>& theTracklayers);
+    static bool import(QWidget* aParent, QByteArray& aFile, Document* theDocument, QList<TrackLayer*>& theTracklayers, Options importOptions);
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ImportGPX::Options)
 
 #endif
 

--- a/src/ImportExport/ImportGPX.h
+++ b/src/ImportExport/ImportGPX.h
@@ -19,6 +19,7 @@ class ImportGPX : public QObject {
         NoOptions = 0x0,
         MakeSegmented = 0x1,
         DetectAnonymizedSegments = 0x2,
+        ForceWaypoints = 0x4,
     };
     Q_DECLARE_FLAGS(Options,Option)
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1658,7 +1658,7 @@ MainWindow::ImportStatus MainWindow::importFile(Document * mapDocument, const QS
         newLayer = new TrackLayer( baseFileName + " - " + tr("Waypoints"), baseFileName);
         mapDocument->add(newLayer);
         theTracklayers.append((TrackLayer*) newLayer);
-        bool importOK = importGPX(this, fileName, mapDocument, theTracklayers);
+        bool importOK = ImportGPX::import(this, fileName, mapDocument, theTracklayers);
         if (!importOK) {
             for (int i=0; i<theTracklayers.size(); i++) {
                 mapDocument->remove(theTracklayers[i]);

--- a/src/Sync/DownloadOSM.cpp
+++ b/src/Sync/DownloadOSM.cpp
@@ -428,7 +428,6 @@ bool downloadTracksFromOSM(QWidget* Main, const QString& aWeb, const QString& aU
             return false;
         if (Before == theTracklayers.size())
             break;
-        theTracklayers[theTracklayers.size()-1]->setName(QApplication::translate("Downloader", "Downloaded track - nodes %1-%2").arg(Page*5000+1).arg(Page*5000+5000));
     }
     return true;
 }

--- a/src/Sync/DownloadOSM.cpp
+++ b/src/Sync/DownloadOSM.cpp
@@ -423,7 +423,7 @@ bool downloadTracksFromOSM(QWidget* Main, const QString& aWeb, const QString& aU
             return false;
         int Before = theTracklayers.size();
         QByteArray Ar(theDownloader.content());
-        bool OK = importGPX(Main, Ar, theDocument, theTracklayers, true);
+        bool OK = ImportGPX::import(Main, Ar, theDocument, theTracklayers, ImportGPX::Option::MakeSegmented | ImportGPX::Option::DetectAnonymizedSegments);
         if (!OK)
             return false;
         if (Before == theTracklayers.size())


### PR DESCRIPTION
This PR fixes issue #181 by adding a heuristics that detects anonymized data when importing GPX from OSM API. This heuristic is not applied on regular GPX imports.