### PR TITLE
Restore coordinate instead of screen point

### DIFF
--- a/src/Interactions/CreatePolygonInteraction.cpp
+++ b/src/Interactions/CreatePolygonInteraction.cpp
@@ -161,6 +161,8 @@ void CreatePolygonInteraction::paintEvent(QPaintEvent* , QPainter& thePainter)
 void CreatePolygonInteraction::mouseMoveEvent(QMouseEvent* event)
 {
     if (HaveOrigin) {
+        OriginF = COORD_TO_XY(Origin);
+
         QMatrix m;
         m.translate(OriginF.x(), OriginF.y());
         m.rotate(bAngle);


### PR DESCRIPTION
This uses the coordinate of the first point and draws the screen rectangle according to a fixed coordinate instead of fixed screen point.

This fixes the main issue, but when panning quickly there are still some minor jumps of the rectangle position noticeable. I am not sure if panning can be made smoother easily, but I did not look into that more closely for now.

refs #125