### PR TITLE
Replace "Road" with "Way" in the user interface, consistent with OSM

### DIFF
--- a/src/Commands/FeatureCommands.cpp
+++ b/src/Commands/FeatureCommands.cpp
@@ -63,7 +63,7 @@ SetTagCommand::SetTagCommand(Feature* aF)
 SetTagCommand::SetTagCommand(Feature* aF, int idx, const QString& k, const QString& v, Layer* aLayer)
 : TagCommand(aF, aLayer), theIdx(idx), theK(k), theV(v)
 {
-    description = QApplication::tr("Set Tag '%1=%2' on %3").arg(k).arg(v).arg(aF->description());
+    description = QApplication::tr("Set tag '%1=%2' on %3").arg(k).arg(v).arg(aF->description());
     oldLayer = theFeature->layer();
     redo();
 }
@@ -71,7 +71,7 @@ SetTagCommand::SetTagCommand(Feature* aF, int idx, const QString& k, const QStri
 SetTagCommand::SetTagCommand(Feature* aF, const QString& k, const QString& v, Layer* aLayer)
 : TagCommand(aF, aLayer), theIdx(-1), theK(k), theV(v)
 {
-    description = QApplication::tr("Set Tag '%1=%2' on %3").arg(k).arg(v).arg(aF->description());
+    description = QApplication::tr("Set tag '%1=%2' on %3").arg(k).arg(v).arg(aF->description());
     oldLayer = theFeature->layer();
     redo();
 }
@@ -185,7 +185,7 @@ SetTagCommand * SetTagCommand::fromXML(Document * d, QXmlStreamReader& stream)
     else
         a->oldLayer = NULL;
 
-    a->description = QApplication::tr("Set Tag '%1=%2' on %3").arg(a->theK).arg(a->theV).arg(a->theFeature->description());
+    a->description = QApplication::tr("Set tag '%1=%2' on %3").arg(a->theK).arg(a->theV).arg(a->theFeature->description());
 
     stream.readNext();
     while(!stream.atEnd() && !stream.isEndElement()) {
@@ -311,7 +311,7 @@ ClearTagCommand::ClearTagCommand(Feature* F)
 ClearTagCommand::ClearTagCommand(Feature* F, const QString& k, Layer* aLayer)
 : TagCommand(F, aLayer), theIdx(F->findKey(k)), theK(k), theV(F->tagValue(k, ""))
 {
-    description = QApplication::tr("Clear Tag '%1' on %2").arg(k).arg(F->description());
+    description = QApplication::tr("Remove tag '%1' from %2").arg(k).arg(F->description());
     oldLayer = theFeature->layer();
     redo();
 }
@@ -397,7 +397,7 @@ ClearTagCommand * ClearTagCommand::fromXML(Document * d, QXmlStreamReader& strea
     else
         a->oldLayer = NULL;
 
-    a->description = QApplication::tr("Clear Tag '%1' on %2").arg(a->theK).arg(a->theFeature->description());
+    a->description = QApplication::tr("Remove tag '%1' from %2").arg(a->theK).arg(a->theFeature->description());
 
     stream.readNext();
     while(!stream.atEnd() && !stream.isEndElement()) {

--- a/src/Docks/FeaturesDock.cpp
+++ b/src/Docks/FeaturesDock.cpp
@@ -467,8 +467,8 @@ void FeaturesDock::retranslateUi()
 void FeaturesDock::retranslateTabBar()
 {
     ui.tabBar->setTabText(0, tr("Relations"));
-    ui.tabBar->setTabText(1, tr("Roads"));
-    ui.tabBar->setTabText(2, tr("POI's"));
+    ui.tabBar->setTabText(1, tr("Ways"));
+    ui.tabBar->setTabText(2, tr("Nodes"));
     ui.tabBar->setTabText(3, tr("All"));
 }
 

--- a/src/Docks/PropertiesDock.cpp
+++ b/src/Docks/PropertiesDock.cpp
@@ -466,7 +466,7 @@ void PropertiesDock::switchToWayUi()
     CurrentUi = NewUi;
     connect(RoadUi.RemoveTagButton,SIGNAL(clicked()),this, SLOT(on_RemoveTagButton_clicked()));
     connect(RoadUi.SourceTagButton,SIGNAL(clicked()),this, SLOT(on_SourceTagButton_clicked()));
-    setWindowTitle(tr("Properties - Road"));
+    setWindowTitle(tr("Properties - Way"));
 }
 
 void PropertiesDock::switchToRelationUi()

--- a/src/Interactions/BuildBridgeInteraction.cpp
+++ b/src/Interactions/BuildBridgeInteraction.cpp
@@ -33,7 +33,7 @@ QString BuildBridgeInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create node Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Build Bridge interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =
@@ -155,7 +155,7 @@ Node *BuildBridgeInteraction::createNode(Coord P, Feature* aFeat)
 	/* Bridge can be only created from existing roads */
     if (aRoad)
     {
-        theList  = new CommandList(MainWindow::tr("Create node in Road: %1").arg(aRoad->id().numId), aRoad);
+        theList  = new CommandList(MainWindow::tr("Create node in way %1").arg(aRoad->id().numId), aRoad);
         int SnapIdx = findSnapPointIndex(aRoad, P);
         N = g_backend.allocNode(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(aRoad->layer()), P);
         theList->add(new AddFeatureCommand(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(aRoad->layer()),N,true));

--- a/src/Interactions/CreateAreaInteraction.cpp
+++ b/src/Interactions/CreateAreaInteraction.cpp
@@ -34,7 +34,7 @@ QString CreateAreaInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Area Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Area interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =

--- a/src/Interactions/CreateDoubleWayDock.ui
+++ b/src/Interactions/CreateDoubleWayDock.ui
@@ -22,7 +22,7 @@
    <item>
     <widget class="QCheckBox" name="DriveRight" >
      <property name="text" >
-      <string>Driving at the right side of the road</string>
+      <string>Road driving on the right</string>
      </property>
     </widget>
    </item>
@@ -37,7 +37,7 @@
      <item>
       <widget class="QLabel" name="label" >
        <property name="text" >
-        <string>Distance between two roads</string>
+        <string>Separation distance</string>
        </property>
       </widget>
      </item>

--- a/src/Interactions/CreateDoubleWayInteraction.cpp
+++ b/src/Interactions/CreateDoubleWayInteraction.cpp
@@ -46,7 +46,7 @@ QString CreateDoubleWayInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create double way Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Parallel Way interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =
@@ -170,7 +170,7 @@ void CreateDoubleWayInteraction::mousePressEvent(QMouseEvent* anEvent)
 
                 Node* A1;
                 Node* A2;
-                CommandList* L  = new CommandList(MainWindow::tr("Add nodes to double-way Road %1").arg(R1->id().numId), R1);
+                CommandList* L  = new CommandList(MainWindow::tr("Add nodes to parallel way %1").arg(R1->id().numId), R1);
                 A1 = R1->getNode(i1);
                 A2 = R2->getNode(i2-1);
                 L->add(new MoveNodeCommand(A1,XY_TO_COORD(
@@ -221,7 +221,7 @@ void CreateDoubleWayInteraction::mousePressEvent(QMouseEvent* anEvent)
                 R1 = g_backend.allocWay(theMain->document()->getDirtyOrOriginLayer());
                 R2 = g_backend.allocWay(theMain->document()->getDirtyOrOriginLayer());
 
-                CommandList* L  = new CommandList(MainWindow::tr("Create double-way Road %1").arg(R1->id().numId), R1);
+                CommandList* L  = new CommandList(MainWindow::tr("Create parallel way %1").arg(R1->id().numId), R1);
                 L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),A1,true));
                 L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),A2,true));
                 L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),B1,true));

--- a/src/Interactions/CreateNodeInteraction.cpp
+++ b/src/Interactions/CreateNodeInteraction.cpp
@@ -30,7 +30,7 @@ QString CreateNodeInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create node Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Node interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =
@@ -109,7 +109,7 @@ void CreateNodeInteraction::createNode(Coord P, Feature* aFeat)
     if (aRoad)
     {
         g_Merk_MainWindow->properties()->setSelection(0);
-        theList  = new CommandList(MainWindow::tr("Create node in Road: %1").arg(aRoad->id().numId), aRoad);
+        theList  = new CommandList(MainWindow::tr("Create node in way %1").arg(aRoad->id().numId), aRoad);
         int SnapIdx = findSnapPointIndex(aRoad, P);
         N = g_backend.allocNode(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(aRoad->layer()), P);
         theList->add(new AddFeatureCommand(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(aRoad->layer()),N,true));
@@ -118,7 +118,7 @@ void CreateNodeInteraction::createNode(Coord P, Feature* aFeat)
     else
     {
         N = g_backend.allocNode(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(), P);
-        theList  = new CommandList(MainWindow::tr("Create POI %1").arg(N->id().numId), N);
+        theList  = new CommandList(MainWindow::tr("Create node %1").arg(N->id().numId), N);
         theList->add(new AddFeatureCommand(g_Merk_MainWindow->document()->getDirtyOrOriginLayer(),N,true));
         if (M_PREFS->getAutoSourceTag()) {
             QStringList sl = g_Merk_MainWindow->document()->getCurrentSourceTags();

--- a/src/Interactions/CreatePolygonInteraction.cpp
+++ b/src/Interactions/CreatePolygonInteraction.cpp
@@ -38,7 +38,7 @@ QString CreatePolygonInteraction::toHtml()
     QStringList helpList = help.split(";");
 
     QString desc;
-    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Create Polygon Interaction"));
+    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Create Polygon interaction"));
 
     QString S =
     "<html><head/><body>"
@@ -87,7 +87,7 @@ void CreatePolygonInteraction::mousePressEvent(QMouseEvent * event)
             QPointF Prev(CenterF.x()+cos(-Angle/2)*Radius,CenterF.y()+sin(-Angle/2)*Radius);
             Node* First = g_backend.allocNode(theMain->document()->getDirtyOrOriginLayer(), XY_TO_COORD(m.map(Prev).toPoint()));
             Way* R = g_backend.allocWay(theMain->document()->getDirtyOrOriginLayer());
-            CommandList* L  = new CommandList(MainWindow::tr("Create Polygon %1").arg(R->id().numId), R);
+            CommandList* L  = new CommandList(MainWindow::tr("Create polygon %1").arg(R->id().numId), R);
             L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),R,true));
             R->add(First);
             L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),First,true));

--- a/src/Interactions/CreateRoundaboutInteraction.cpp
+++ b/src/Interactions/CreateRoundaboutInteraction.cpp
@@ -56,7 +56,7 @@ QString CreateRoundaboutInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create roundabout Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Roundabout interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =

--- a/src/Interactions/CreateSingleWayInteraction.cpp
+++ b/src/Interactions/CreateSingleWayInteraction.cpp
@@ -56,7 +56,7 @@ QString CreateSingleWayInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create way Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create Way interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =
@@ -238,7 +238,7 @@ void CreateSingleWayInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Fea
                 Coord P(XY_TO_COORD(LastCursor));
                 int SnapIdx = findSnapPointIndex(aRoad, P);
                 Node* N = g_backend.allocNode(theMain->document()->getDirtyOrOriginLayer(), P);
-                CommandList* theList  = new CommandList(MainWindow::tr("Create Node %1 in Road %2").arg(N->description()).arg(aRoad->description()), N);
+                CommandList* theList  = new CommandList(MainWindow::tr("Create node %1 in way %2").arg(N->description()).arg(aRoad->description()), N);
                 theList->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),N,true));
                 theList->add(new WayAddNodeCommand(aRoad,N,SnapIdx,theMain->document()->getDirtyOrOriginLayer(aRoad)));
                 document()->addHistory(theList);
@@ -282,7 +282,7 @@ void CreateSingleWayInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Fea
                 if (IsCurved)
                     theRoad->setTag("smooth","yes");
                 L->add(new WayAddNodeCommand(theRoad,From));
-                L->setDescription(MainWindow::tr("Create Road: %1").arg(theRoad->description()));
+                L->setDescription(MainWindow::tr("Create way %1").arg(theRoad->description()));
                 L->setFeature(theRoad);
             }
             Node* To = 0;
@@ -290,7 +290,7 @@ void CreateSingleWayInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Fea
                 To = Pt;
                 if (!To->isDirty() && !To->hasOSMId() && To->isUploadable()) {
                     L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),To,true));
-                    L->setDescription(MainWindow::tr("Create Node: %1").arg(To->description()));
+                    L->setDescription(MainWindow::tr("Create node: %1").arg(To->description()));
                 }
             }
             else if (Way* aRoad = dynamic_cast<Way*>(lastSnap))
@@ -298,7 +298,7 @@ void CreateSingleWayInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Fea
                 Coord P(XY_TO_COORD(LastCursor));
                 int SnapIdx = findSnapPointIndex(aRoad, P);
                 Node* N = g_backend.allocNode(theMain->document()->getDirtyOrOriginLayer(), P);
-                CommandList* theList  = new CommandList(MainWindow::tr("Create Node %1 in Road %2").arg(N->description()).arg(aRoad->description()), N);
+                CommandList* theList  = new CommandList(MainWindow::tr("Create node %1 in way %2").arg(N->description()).arg(aRoad->description()), N);
                 theList->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),N,true));
                 theList->add(new WayAddNodeCommand(aRoad,N,SnapIdx,theMain->document()->getDirtyOrOriginLayer(aRoad)));
                 document()->addHistory(theList);
@@ -309,10 +309,10 @@ void CreateSingleWayInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Fea
             {
                 To = g_backend.allocNode(theMain->document()->getDirtyOrOriginLayer(), XY_TO_COORD(LastCursor));
                 L->add(new AddFeatureCommand(theMain->document()->getDirtyOrOriginLayer(),To,true));
-                L->setDescription(MainWindow::tr("Create Node %1 in Road %2").arg(To->description()).arg(theRoad->description()));
+                L->setDescription(MainWindow::tr("Create node %1 in way %2").arg(To->description()).arg(theRoad->description()));
                 L->setFeature(To);
             }
-            L->setDescription(MainWindow::tr("Add Node %1 to Road %2").arg(To->description()).arg(theRoad->description()));
+            L->setDescription(MainWindow::tr("Add node %1 to way %2").arg(To->description()).arg(theRoad->description()));
             if (Prepend)
                 L->add(new WayAddNodeCommand(theRoad,To,(int)0,theMain->document()->getDirtyOrOriginLayer(theRoad)));
             else

--- a/src/Interactions/EditInteraction.cpp
+++ b/src/Interactions/EditInteraction.cpp
@@ -56,7 +56,7 @@ QString EditInteraction::toHtml()
     QStringList helpList = help.split(";");
 
     QString desc;
-    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Edit Interaction"));
+    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Edit interaction"));
 
     QString S =
     "<html><head/><body>"

--- a/src/Interactions/ExtrudeInteraction.cpp
+++ b/src/Interactions/ExtrudeInteraction.cpp
@@ -40,7 +40,7 @@ QString ExtrudeInteraction::toHtml()
     //help = (MainWindow::tr("LEFT-CLICK to select; LEFT-DRAG to move"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Create way Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Extrude interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =
@@ -130,7 +130,7 @@ void ExtrudeInteraction::snapMouseReleaseEvent(QMouseEvent* anEvent, Feature* la
         QLineF s2 = QLineF::fromPolar(OrigSegment.length(), OrigSegment.angle());
         s2.translate(pb);
 
-        CommandList* theList  = new CommandList(MainWindow::tr("Extrude Road %1").arg(theRoad->description()), theRoad);
+        CommandList* theList  = new CommandList(MainWindow::tr("Extrude way %1").arg(theRoad->description()), theRoad);
         if (theRoad->segmentCount() == 1) {
             int pos = 0;
             Node* N = g_backend.allocNode(theRoad->layer(), XY_TO_COORD(s2.p1().toPoint()));

--- a/src/Interactions/MoveNodeInteraction.cpp
+++ b/src/Interactions/MoveNodeInteraction.cpp
@@ -44,7 +44,7 @@ QString MoveNodeInteraction::toHtml()
     QStringList helpList = help.split(";");
 
     QString desc;
-    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Move node Interaction"));
+    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Move Node interaction"));
 
     QString S =
     "<html><head/><body>"
@@ -151,11 +151,11 @@ void MoveNodeInteraction::snapMouseReleaseEvent(QMouseEvent * event, Feature* Cl
     {
         Coord Diff(calculateNewPosition(event,Closer, theList)-StartDragPosition);
         if (Moving.size() > 1) {
-            theList->setDescription(MainWindow::tr("Move Nodes"));
+            theList->setDescription(MainWindow::tr("Move nodes"));
             theList->setFeature(Moving[0]);
         } else {
             if (!Virtual) {
-                theList->setDescription(MainWindow::tr("Move Node %1").arg(Moving[0]->id().numId));
+                theList->setDescription(MainWindow::tr("Move node %1").arg(Moving[0]->id().numId));
                 theList->setFeature(Moving[0]);
             }
         }
@@ -218,7 +218,7 @@ void MoveNodeInteraction::snapMouseReleaseEvent(QMouseEvent * event, Feature* Cl
                     // Merge all nodes into the first node that has been found (not the node being moved)
                     Node* merged = samePosPts[0];
                     // Change the command description to reflect the merge
-                    theList->setDescription(MainWindow::tr("Merge Nodes into %1").arg(merged->id().numId));
+                    theList->setDescription(MainWindow::tr("Merge nodes into %1").arg(merged->id().numId));
                     theList->setFeature(merged);
 
                     // from mergeNodes(theDocument, theList, theProperties);
@@ -258,7 +258,7 @@ void MoveNodeInteraction::snapMouseMoveEvent(QMouseEvent* event, Feature* Closer
                 Virtual = true;
                 Node* v = Moving[i];
                 Way* aRoad = CAST_WAY(v->getParent(0));
-                theList->setDescription(MainWindow::tr("Create node in Road: %1").arg(aRoad->id().numId));
+                theList->setDescription(MainWindow::tr("Create node in way %1").arg(aRoad->id().numId));
                 theList->setFeature(aRoad);
                 int SnapIdx = aRoad->findVirtual(v)+1;
                 Node* N = g_backend.allocNode(main()->document()->getDirtyOrOriginLayer(aRoad->layer()), *v);

--- a/src/Interactions/RotateInteraction.cpp
+++ b/src/Interactions/RotateInteraction.cpp
@@ -41,7 +41,7 @@ QString RotateInteraction::toHtml()
     QStringList helpList = help.split(";");
 
     QString desc;
-    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Rotate Interaction"));
+    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Rotate interaction"));
 
     QString S =
     "<html><head/><body>"

--- a/src/Interactions/ScaleInteraction.cpp
+++ b/src/Interactions/ScaleInteraction.cpp
@@ -41,7 +41,7 @@ QString ScaleInteraction::toHtml()
     QStringList helpList = help.split(";");
 
     QString desc;
-    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Scale Interaction"));
+    desc = QString("<big><b>%1</b></big>").arg(MainWindow::tr("Scale interaction"));
 
     QString S =
     "<html><head/><body>"

--- a/src/Interactions/ZoomInteraction.cpp
+++ b/src/Interactions/ZoomInteraction.cpp
@@ -27,7 +27,7 @@ QString ZoomInteraction::toHtml()
     help = (MainWindow::tr("LEFT-CLICK to first corner -> LEFT-DRAG to specify area -> LEFT-CLICK to zoom"));
 
     QString desc;
-    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Zoom Interaction"));
+    desc = QString("<big><b>%1</b></big><br/>").arg(MainWindow::tr("Zoom interaction"));
     desc += QString("<b>%1</b><br/>").arg(help);
 
     QString S =

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -622,7 +622,7 @@ void MainWindow::onCustomcontextmenurequested(const QPoint & pos)
         if (nodeMenu.actions().size())
             menu.addMenu(&nodeMenu);
 
-        QMenu roadMenu(tr("Road"));
+        QMenu roadMenu(tr("Way"));
         for(int i=0; i<ui->menuRoad->actions().size(); ++i) {
             if (ui->menuRoad->actions()[i]->isEnabled())
                 roadMenu.addAction(ui->menuRoad->actions()[i]);
@@ -2440,7 +2440,7 @@ void MainWindow::on_markBridgeAction_triggered()
 
 void MainWindow::on_roadJoinAction_triggered()
 {
-    CommandList* theList = new CommandList(MainWindow::tr("Join Roads"), NULL);
+    CommandList* theList = new CommandList(MainWindow::tr("Join Ways"), NULL);
     joinRoads(theDocument, theList, p->theProperties);
     if (theList->empty())
         delete theList;
@@ -2454,7 +2454,7 @@ void MainWindow::on_roadJoinAction_triggered()
 
 void MainWindow::on_roadSplitAction_triggered()
 {
-    CommandList* theList = new CommandList(MainWindow::tr("Split Roads"), NULL);
+    CommandList* theList = new CommandList(MainWindow::tr("Split Ways"), NULL);
     splitRoads(theDocument, theList, p->theProperties);
     if (theList->empty())
         delete theList;
@@ -2468,7 +2468,7 @@ void MainWindow::on_roadSplitAction_triggered()
 
 void MainWindow::on_roadBreakAction_triggered()
 {
-    CommandList* theList = new CommandList(MainWindow::tr("Break Roads"), NULL);
+    CommandList* theList = new CommandList(MainWindow::tr("Break Ways"), NULL);
     breakRoads(theDocument, theList, p->theProperties);
     if (theList->empty())
         delete theList;
@@ -2482,7 +2482,7 @@ void MainWindow::on_roadBreakAction_triggered()
 
 void MainWindow::on_roadSimplifyAction_triggered()
 {
-    CommandList* theList = new CommandList(MainWindow::tr("Simplify Roads"), NULL);
+    CommandList* theList = new CommandList(MainWindow::tr("Simplify Ways"), NULL);
     qreal threshold = 3.0; // in metres; TODO: allow user-specified threshold
     simplifyRoads(theDocument, theList, p->theProperties, threshold);
     if (theList->empty())
@@ -2616,7 +2616,7 @@ void MainWindow::on_roadSubdivideAction_triggered()
     if (Dlg->exec() == QDialog::Accepted) {
         int divisions = Dlg->intValue();
 #endif
-        CommandList* theList = new CommandList(MainWindow::tr("Subdivide road into %1").arg(divisions), NULL);
+        CommandList* theList = new CommandList(MainWindow::tr("Subdivide way into %1").arg(divisions), NULL);
         subdivideRoad(theDocument, theList, p->theProperties, divisions);
         if (theList->empty())
             delete theList;

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -48,7 +48,7 @@
    </widget>
    <widget class="QMenu" name="menuRoad">
     <property name="title">
-     <string>&amp;Road</string>
+     <string>Wa&amp;y</string>
     </property>
     <addaction name="roadSplitAction"/>
     <addaction name="roadBreakAction"/>
@@ -101,12 +101,12 @@
     </widget>
     <widget class="QMenu" name="mnuProjections">
      <property name="title">
-      <string>Set &amp;projection</string>
+      <string>&amp;Projection</string>
      </property>
     </widget>
     <widget class="QMenu" name="mnuAreaOpacity">
      <property name="title">
-      <string>Set Areas &amp;opacity</string>
+      <string>Area &amp;opacity</string>
      </property>
     </widget>
     <addaction name="viewZoomAllAction"/>
@@ -328,6 +328,7 @@
    <addaction name="menuRelation"/>
    <addaction name="menuTools"/>
    <addaction name="menuWindow"/>
+   <addaction name="separator"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="StatusBar"/>
@@ -645,10 +646,10 @@
      <normaloff>:/Icons/actions/create_road.png</normaloff>:/Icons/actions/create_road.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Road</string>
+    <string>&amp;Way</string>
    </property>
    <property name="toolTip">
-    <string>Create new road</string>
+    <string>Create new way</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+R</string>
@@ -684,7 +685,7 @@
     <string>&amp;Reverse</string>
    </property>
    <property name="toolTip">
-    <string>Reverse road direction</string>
+    <string>Reverse way direction</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -704,10 +705,10 @@
   </action>
   <action name="createDoubleWayAction">
    <property name="text">
-    <string>&amp;Double carriage way</string>
+    <string>&amp;Parallel way</string>
    </property>
    <property name="toolTip">
-    <string>Create Double carriage way</string>
+    <string>Create a parallel way</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -751,7 +752,7 @@
     <string>&amp;Split</string>
    </property>
    <property name="toolTip">
-    <string>Split road into separate (connected) roads</string>
+    <string>Split way into separate (connected) ways</string>
    </property>
    <property name="shortcut">
     <string notr="true">Alt+S</string>
@@ -766,7 +767,7 @@
     <string>&amp;Join</string>
    </property>
    <property name="toolTip">
-    <string>Join connected roads into a single road</string>
+    <string>Join connected ways into a single way</string>
    </property>
    <property name="shortcut">
     <string notr="true">Alt+J</string>
@@ -784,7 +785,7 @@
     <string>Break</string>
    </property>
    <property name="toolTip">
-    <string>Break apart connected roads</string>
+    <string>Break apart connected ways</string>
    </property>
    <property name="shortcut">
     <string notr="true">Alt+B</string>
@@ -813,7 +814,7 @@
     <string>&amp;Area</string>
    </property>
    <property name="toolTip">
-    <string>New area</string>
+    <string>Create new area</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -845,7 +846,7 @@
   </action>
   <action name="createCurvedRoadAction">
    <property name="text">
-    <string>&amp;Curved road</string>
+    <string>&amp;Curved way</string>
    </property>
   </action>
   <action name="toolsPreferencesAction">
@@ -1101,7 +1102,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show &amp;downloaded areas</string>
+    <string>&amp;Downloaded areas</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+A</string>
@@ -1282,7 +1283,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show &amp;nodes</string>
+    <string>&amp;Nodes</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+P</string>
@@ -1293,7 +1294,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show na&amp;mes</string>
+    <string>Na&amp;mes</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+N</string>
@@ -1368,7 +1369,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show track &amp;segments</string>
+    <string>Track &amp;segments</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+T</string>
@@ -1379,7 +1380,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show &amp;scale</string>
+    <string>&amp;Scale</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+S</string>
@@ -1390,7 +1391,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show &amp;relations</string>
+    <string>&amp;Relations</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Alt+R</string>
@@ -1558,7 +1559,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>for &amp;oneway roads</string>
+    <string>For 'oneway' ways</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -1584,10 +1585,10 @@
     <string>&amp;Detach</string>
    </property>
    <property name="toolTip">
-    <string>Detach node from a road</string>
+    <string>Detach node from a way</string>
    </property>
    <property name="statusTip">
-    <string>Detach a node from a Road</string>
+    <string>Detach a node from a way</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -1713,7 +1714,7 @@
   </action>
   <action name="layersNewImageAction">
    <property name="text">
-    <string>Add &amp;image layer</string>
+    <string>Add new &amp;image layer</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -1772,7 +1773,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Lat/lon &amp;grid</string>
+    <string>Lat/Lon &amp;grid</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -1826,7 +1827,7 @@
   </action>
   <action name="layersOpenstreetbugsAction">
    <property name="text">
-    <string>Add OpenStreet&amp;Bugs layer</string>
+    <string>Add new OpenStreet&amp;Bugs layer</string>
    </property>
   </action>
   <action name="featureOsbClose">
@@ -1920,7 +1921,7 @@
   </action>
   <action name="toolsToolbarsAction">
    <property name="text">
-    <string>Toolbar Editor…</string>
+    <string>Toolbar editor…</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -1998,7 +1999,7 @@
   </action>
   <action name="layersNewFilterAction">
    <property name="text">
-    <string>Add new &amp;Filter layer</string>
+    <string>Add new &amp;filter layer</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -2101,7 +2102,7 @@
   </action>
   <action name="layersMapdustAction">
    <property name="text">
-    <string>Add Map&amp;dust layer</string>
+    <string>Add new Map&amp;dust layer</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>

--- a/src/common/TagModel.cpp
+++ b/src/common/TagModel.cpp
@@ -139,9 +139,9 @@ bool TagModel::setData(const QModelIndex &index, const QVariant &value, int role
                 beginInsertRows(QModelIndex(), Tags.size()+1, Tags.size()+1);
                 CommandList* L;
                 if (theFeatures.size() > 1)
-                    L = new CommandList(MainWindow::tr("Set Tags on multiple features"), NULL);
+                    L = new CommandList(MainWindow::tr("Set tags on multiple features"), NULL);
                 else
-                    L = new CommandList(MainWindow::tr("Set Tags on %1").arg(theFeatures[0]->id().numId), theFeatures[0]);
+                    L = new CommandList(MainWindow::tr("Set tags on %1").arg(theFeatures[0]->id().numId), theFeatures[0]);
                 for (int i=0; i<theFeatures.size(); ++i)
                 {
                     if (theFeatures[i]->isVirtual())
@@ -170,9 +170,9 @@ bool TagModel::setData(const QModelIndex &index, const QVariant &value, int role
                 Tags[index.row()].second = value.toString();
             CommandList* L;
             if (theFeatures.size() > 1)
-                L = new CommandList(MainWindow::tr("Set Tags on multiple features"), NULL);
+                L = new CommandList(MainWindow::tr("Set tags on multiple features"), NULL);
             else
-                L = new CommandList(MainWindow::tr("Set Tags on %1").arg(theFeatures[0]->id().numId), theFeatures[0]);
+                L = new CommandList(MainWindow::tr("Set tags on %1").arg(theFeatures[0]->id().numId), theFeatures[0]);
             for (int i=0; i<theFeatures.size(); ++i)
             {
                 if (theFeatures[i]->isVirtual())


### PR DESCRIPTION
"Way" is the OpenStreetMap term used for any linear feature, so this
makes the terminology in Merkaartor consistent with OSM.  Also included
are some case and punctuation fixes observed while making that change.

Fixes #160.