### PR TITLE
Fix HTTP Date header

### DIFF
--- a/src/Utils/RemoteControlServer.cpp
+++ b/src/Utils/RemoteControlServer.cpp
@@ -15,6 +15,49 @@
 using namespace Merkaartor;
 using namespace Merkaartor::RemoteControlServerPriv;
 
+static QString date_time_rfc7231() {
+    const auto now = QDateTime::currentDateTimeUtc();
+
+    //generate format string to format UTC timestamp similar to
+    //"Sun, 06 Nov 1994 08:49:37 GMT"
+    //use *non-localized* names for day & month.
+
+    QString fmt_IMF_fixdate;
+    fmt_IMF_fixdate.reserve(35);
+
+    switch(now.date().dayOfWeek()) {
+        case Qt::Monday: fmt_IMF_fixdate.append("'Mon'"); break;
+        case Qt::Tuesday: fmt_IMF_fixdate.append("'Tue'"); break;
+        case Qt::Wednesday: fmt_IMF_fixdate.append("'Wed'"); break;
+        case Qt::Thursday: fmt_IMF_fixdate.append("'Thu'"); break;
+        case Qt::Friday: fmt_IMF_fixdate.append("'Fri'"); break;
+        case Qt::Saturday: fmt_IMF_fixdate.append("'Sat'"); break;
+        case Qt::Sunday: fmt_IMF_fixdate.append("'Sun'"); break;
+        //other values are possible, so use localized name as fallback
+        default: fmt_IMF_fixdate.append("ddd"); break;
+    }
+    fmt_IMF_fixdate.append(", dd ");
+    switch(now.date().month()) {
+        case  1: fmt_IMF_fixdate.append("'Jan'"); break;
+        case  2: fmt_IMF_fixdate.append("'Feb'"); break;
+        case  3: fmt_IMF_fixdate.append("'Mar'"); break;
+        case  4: fmt_IMF_fixdate.append("'Apr'"); break;
+        case  5: fmt_IMF_fixdate.append("'May'"); break;
+        case  6: fmt_IMF_fixdate.append("'Jun'"); break;
+        case  7: fmt_IMF_fixdate.append("'Jul'"); break;
+        case  8: fmt_IMF_fixdate.append("'Aug'"); break;
+        case  9: fmt_IMF_fixdate.append("'Sep'"); break;
+        case 10: fmt_IMF_fixdate.append("'Oct'"); break;
+        case 11: fmt_IMF_fixdate.append("'Nov'"); break;
+        case 12: fmt_IMF_fixdate.append("'Dec'"); break;
+        //other values are possible, so use localized name as fallback
+        default: fmt_IMF_fixdate.append("MMM"); break;
+    }
+    fmt_IMF_fixdate.append(" yyyy HH:mm:ss 'GMT'");
+
+    return now.toString(fmt_IMF_fixdate);
+};
+
 void RemoteControlConnection::readyRead() {
     qDebug() << "RemoteControlConnection: readyRead.";
     if ( m_socket->canReadLine() ) {
@@ -23,7 +66,7 @@ void RemoteControlConnection::readyRead() {
         QStringList tokens = ln.split( QRegExp("[ \r\n][ \r\n]*"), QString::SkipEmptyParts );
         if ( tokens[0] == "GET" ) {
             m_responseStream << "HTTP/1.1 200 OK\r\n";
-            m_responseStream << "Date: " << QDateTime::currentDateTime().toString(Qt::TextDate);
+            m_responseStream << "Date: " << date_time_rfc7231() << "\r\n";
             m_responseStream << "Server: Merkaartor RemoteControl\r\n";
             m_responseStream << "Content-type: text/plain\r\n";
             m_responseStream << "Access-Control-Allow-Origin: *\r\n";
@@ -38,7 +81,7 @@ void RemoteControlConnection::readyRead() {
     }
 }
 
-RemoteControlConnection::RemoteControlConnection( QTcpSocket *socket ) 
+RemoteControlConnection::RemoteControlConnection( QTcpSocket *socket )
     : m_socket(socket), m_responseStream(socket)
 {
     connect( m_socket, &QTcpSocket::readyRead, this, &RemoteControlConnection::readyRead);
@@ -47,7 +90,7 @@ RemoteControlConnection::RemoteControlConnection( QTcpSocket *socket )
 }
 
 
-RemoteControlServer::RemoteControlServer( QObject* parent ) 
+RemoteControlServer::RemoteControlServer( QObject* parent )
     :QObject(parent)
 {
     m_tcpServer = new QTcpServer(this);
@@ -75,12 +118,12 @@ void RemoteControlServer::newConnection() {
      * For now, we make sure the main EventLoop is executing the download
      * dialogs and hopefully avoid this problem.
      */
-    connect( connHandler, &RemoteControlConnection::requestReceived, 
+    connect( connHandler, &RemoteControlConnection::requestReceived,
             this, [this](QString requestUrl) { emit requestReceived(requestUrl); }, Qt::QueuedConnection);
 
 }
 
-void RemoteControlServer::listen() { 
+void RemoteControlServer::listen() {
     if (!m_tcpServer->listen( QHostAddress::LocalHost, 8111 )) {
         qWarning() << "Unable to open port localhost:8111: " << m_tcpServer->errorString();
     }


### PR DESCRIPTION
As @KrilleGH pointed out #208 the `Date` header was missing the required CRLF line ending and using a date format not conforming to [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.1).

This patch uses the recommended, non-localized IMF-fixdate format and adds the missing line endings.