### PR TITLE
COMPILE.md: Remove outdated note

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -164,9 +164,8 @@ On Windows:           $ make release
 On other platforms:   $ make
 Debug build:          $ make debug
 
-On Linux, make release fails, as the qmake does not generate proper goal in
-Makefiles, but release is the default. On most Windows installations, the debug
-is the default and we need to specify the release manually. Sorry about that.
+On most Windows installations, debug is the default and we need to specify
+the release manually. Sorry about that.
 
 ### Done!
 


### PR DESCRIPTION
I had no problems on Ubuntu 18.04.4 LTS and qmake 5.9.5.