### PR TITLE
Add QT_NO_DEPRECATED_WARNINGS define

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An opensource OSM editor, written in C++ and Qt.
 Binary installation files are available for various Linux distributions and Windows. 
 
 These Linux distributions are known to provide current versions of Merkaartor:
- - Arch (via AUR)
+ - Arch via [AUR](https://aur.archlinux.org/packages/merkaartor-git/) ([git clone url](https://aur.archlinux.org/merkaartor-git.git))
  - Debian
  - Fedora
  - Gentoo

--- a/plugins/common.pri
+++ b/plugins/common.pri
@@ -11,6 +11,8 @@ QT_VER_MIN = $$member(QT_VERSION, 1)
 MERKAARTOR_SRC_DIR = $$PWD/..
 
 CONFIG += debug_and_release
+# avoid deprecation warnings which 5.15 introduced.
+DEFINES += QT_NO_DEPRECATED_WARNINGS
 
 #Static config
 include ($$MERKAARTOR_SRC_DIR/src/Config.pri)

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,6 +7,8 @@ include (Config.pri)
 include(Custom.pri)
 
 CONFIG += debug_and_release c++11
+# avoid deprecation warnings which 5.15 introduced.
+DEFINES += QT_NO_DEPRECATED_WARNINGS
 
 # This is a workaround to get qDebug() to stdout on Windows. Uncomment if needed.
 win32 {


### PR DESCRIPTION
Since Qt5.15 a lot of new methods and enums have been added which Qt6 will make mandatory. These generate deprecation warnings for those compiling on 5.15.*

As long as 5.15 is not mandatory these warnings are just annoying as following their advice makes your app no longer compile on versions older than 5.15