### PR TITLE
Avoid gcc warnings.

### DIFF
--- a/src/common/Coord.h
+++ b/src/common/Coord.h
@@ -58,6 +58,9 @@ class Coord : public QPointF
         bool toXML(QString elName, QDomElement& xParent) const;
         static Coord fromXML(QDomElement e);
         static Coord fromXML(QXmlStreamReader& stream);
+
+
+        Coord& operator=(const Coord&) = default;
 };
 
 uint qHash(const Coord &c);
@@ -191,6 +194,8 @@ class CoordBox : public QRectF
         bool toXML(QString elName, QDomElement& xParent) const;
         static CoordBox fromXML(QDomElement e);
         static CoordBox fromXML(QXmlStreamReader& stream);
+
+        CoordBox& operator=(const CoordBox&) = default;
 };
 
 Q_DECLARE_METATYPE( CoordBox );


### PR DESCRIPTION
Operator= is now explicitly implemented.

A lot of this kind of warnings came by while compiling on the latest gcc:

```
In file included from ../../../merkaartor/src/common/Coord.cpp:1:
../../../merkaartor/src/common/Coord.h:41:9: note: because ‘Coord’ has user-provided ‘Coord::Coord(const Coord&)’
   41 |         Coord(const Coord& c)
      |         ^~~~~
```

This PR fixes those warnings.