### PR TITLE
Fix unintentional fall-through

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1014,6 +1014,7 @@ bool MainWindow::eventFilter(QObject */* watched */, QEvent *event)
 
             }
         }
+        break;
 
     case QEvent::KeyRelease: {
             QKeyEvent *ke = static_cast< QKeyEvent* >( event );
@@ -1052,6 +1053,7 @@ bool MainWindow::eventFilter(QObject */* watched */, QEvent *event)
                 break;
             }
         }
+        break;
 
     case QEvent::Leave: {
             if (theInfo)


### PR DESCRIPTION
gcc warned me about two missing 'break' statements in a switch. Upon investigation I concluded, with my limited knowledge of the app, that this was an oversight and thus added those break statements in this PR.