### PR TITLE
Add standard keyboard shortcut for quit

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -389,7 +389,7 @@
     <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
-    <string notr="true"/>
+    <string>Ctrl+Q</string>
    </property>
    <property name="menuRole">
     <enum>QAction::QuitRole</enum>


### PR DESCRIPTION
As the title suggests.

This allows users to use Ctrl-Q to initiate the closing of the app.