### PR TITLE
Fix QDebug usage

### DIFF
--- a/src/Commands/Command.cpp
+++ b/src/Commands/Command.cpp
@@ -314,7 +314,7 @@ CommandList* CommandList::fromXML(Document* d, QXmlStreamReader& stream)
         } else if (stream.name() == "CommandList") {
             l->add(CommandList::fromXML(d, stream));
         } else if (!stream.isWhitespace()) {
-                qDebug() << "CList: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                qDebug() << "CList: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                 QString el = stream.readElementText(QXmlStreamReader::IncludeChildElements);
         }
         stream.readNext();
@@ -545,7 +545,7 @@ CommandHistory* CommandHistory::fromXML(Document* d, QXmlStreamReader& stream, Q
             else
                 OK = false;
         } else if (!stream.isWhitespace()) {
-            qDebug() << "CHist: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "CHist: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             QString el = stream.readElementText(QXmlStreamReader::IncludeChildElements);
         }
 
@@ -558,8 +558,8 @@ CommandHistory* CommandHistory::fromXML(Document* d, QXmlStreamReader& stream, Q
 
     if (!OK) {
         qDebug() << "!! File history is corrupted. Resetting...";
-        qDebug() << "-- Size: " << h->Size;
-        qDebug() << "-- Index: " << h->Index;
+        qDebug() << "-- Size:" << h->Size;
+        qDebug() << "-- Index:" << h->Index;
         delete h;
         h = new CommandHistory();
     } else

--- a/src/Commands/FeatureCommands.cpp
+++ b/src/Commands/FeatureCommands.cpp
@@ -162,7 +162,7 @@ SetTagCommand * SetTagCommand::fromXML(Document * d, QXmlStreamReader& stream)
 {
     Feature* F;
     if (!(F = d->getFeature(IFeature::FId(IFeature::All, stream.attributes().value("feature").toString().toLongLong())))) {
-        qDebug() << "SetTagCommand::fromXML: Undefined feature: " << stream.attributes().value("feature").toString();
+        qDebug() << "SetTagCommand::fromXML: Undefined feature:" << stream.attributes().value("feature").toString();
         return NULL;
     }
 

--- a/src/Docks/GeoImageDock.cpp
+++ b/src/Docks/GeoImageDock.cpp
@@ -636,9 +636,9 @@ void GeoImageDock::loadImages(QStringList fileNames)
                 // extract results
                 for(zbar::Image::SymbolIterator symbol = image.symbol_begin(); symbol != image.symbol_end(); ++symbol) {
                     // do something useful with results
-                    qDebug() << "decoded " << QString::fromStdString(symbol->get_type_name())
+                    qDebug() << "decoded" << QString::fromStdString(symbol->get_type_name())
                             << " symbol \"" << QString::fromStdString(symbol->get_data()) << '"';
-                    qDebug() << "x;y: " << symbol->get_location_x(0) << ", " << symbol->get_location_y(0);
+                    qDebug() << "x;y:" << symbol->get_location_x(0) << "," << symbol->get_location_y(0);
 
                     url = QUrl(QString::fromStdString(symbol->get_data()));
                     if (url.host().contains("walking-papers.org")) {

--- a/src/Docks/LayerDock.cpp
+++ b/src/Docks/LayerDock.cpp
@@ -314,7 +314,7 @@ void LayerDock::layerCleared(Layer* l)
 void LayerDock::layerZoom(Layer * l)
 {
     CoordBox bb = l->boundingBox();
-    qDebug() << "layerZoom: " << bb.topLeft().y() << ";" << bb.topLeft().x() << ";" << bb.bottomRight().y() << ";" << bb.bottomRight().x();
+    qDebug() << "layerZoom:" << bb.topLeft().y() << ";" << bb.topLeft().x() << ";" << bb.bottomRight().y() << ";" << bb.bottomRight().x();
     if (bb.isNull())
         return;
 

--- a/src/Features/Feature.cpp
+++ b/src/Features/Feature.cpp
@@ -101,7 +101,7 @@ public:
     {
 #ifndef FRISIUS_BUILD
         initVersionNumber();
-        //            qDebug() << "MapFeaturePrivate size: " << sizeof(FeaturePrivate) << sizeof(IFeature::FId) << sizeof(RenderPriority);
+        //            qDebug() << "MapFeaturePrivate size:" << sizeof(FeaturePrivate) << sizeof(IFeature::FId) << sizeof(RenderPriority);
 #endif
     }
     FeaturePrivate(const FeaturePrivate& other)
@@ -167,7 +167,7 @@ Feature::Feature()
     p = new FeaturePrivate(this);
     p->Id = IFeature::FId(IFeature::Uninitialized, 0);
 
-    //     qDebug() << "Feature size: " << sizeof(Feature);
+    //     qDebug() << "Feature size:" << sizeof(Feature);
 }
 
 Feature::Feature(const Feature& other)

--- a/src/Features/Node.cpp
+++ b/src/Features/Node.cpp
@@ -16,7 +16,7 @@ Node::Node(const Coord& aCoord)
     , ProjectionRevision(0)
 {
     BBox = CoordBox(aCoord, aCoord);
-//    qDebug() << "Node size: " << sizeof(Node) << sizeof(PhotoNode);
+//    qDebug() << "Node size:" << sizeof(Node) << sizeof(PhotoNode);
 
 }
 
@@ -170,7 +170,7 @@ void Node::drawSimple(QPainter &P, MapView *theView)
         //        if (!Pt->isReadonly() && Pt->isSelectable(r))
     {
         if (!layer()) {
-            qDebug() << "Node without layer: " << id().numId << xmlId();
+            qDebug() << "Node without layer:" << id().numId << xmlId();
             return;
         }
         qreal WW = theView->nodeWidth();

--- a/src/Features/Relation.cpp
+++ b/src/Features/Relation.cpp
@@ -687,7 +687,7 @@ Relation * Relation::fromXML(Document * d, Layer * L, QXmlStreamReader& stream)
             hasBbox = true;
             stream.readNext();
         } else if (!stream.isWhitespace()) {
-            qDebug() << "Relation: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "Relation: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
         stream.readNext();

--- a/src/Features/Way.cpp
+++ b/src/Features/Way.cpp
@@ -841,7 +841,7 @@ Way * Way::fromXML(Document* d, Layer * L, QXmlStreamReader& stream)
             hasBbox = true;
             stream.readNext();
         } else if (!stream.isWhitespace()) {
-            qDebug() << "Way: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "Way: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
 

--- a/src/GPS/qgpsdevice.cpp
+++ b/src/GPS/qgpsdevice.cpp
@@ -589,8 +589,8 @@ bool QGPSDevice::parseGSV(const char *gsvString)
     currentSentence = tokens[2].toInt();
     totalSatellites = tokens[3].toInt();
 
-    qDebug() << "Parsing GSV string " << gsvString;
-    qDebug() << " --> sentence " << currentSentence << " of " << totalSentences << ", " << totalSatellites << " total satellites in view";
+    qDebug() << "Parsing GSV string" << gsvString;
+    qDebug() << " --> sentence" << currentSentence << "of " << totalSentences << "," << totalSatellites << "total satellites in view";
 
     for(int i = 0; (i < 4) && ((i*4)+4+3 < tokens.size()); i ++) {
         prn = tokens[(i*4)+4].toInt();
@@ -1018,7 +1018,7 @@ void QGPSDDevice::onDataAvailable()
        if (!gpsdata)
            {
            QString msg( (errno==0) ? "socket to gpsd was closed" : strerror(errno) );
-           qDebug() << "gpsmm::read() failed: " << msg;
+           qDebug() << "gpsmm::read() failed:" << msg;
            serverOk = false;
            return;
            }
@@ -1098,7 +1098,7 @@ void QGPSDDevice::onLinkReady()
     gpsdata = Server->stream(WATCH_ENABLE);
 #ifndef Q_OS_WIN32
     if ( gpsdata == 0 )
-        qDebug() << "gpsmm::stream() failed: " << gps_errstr(errno) << '\n';
+        qDebug() << "gpsmm::stream() failed:" << gps_errstr(errno) << '\n';
 #endif
 #else
     gpsdata = Server->query("w+x\n");
@@ -1190,7 +1190,7 @@ void QGPSDDevice::onDataAvailable()
 
 void QGPSDDevice::parse(const QString& s)
 {
-    qDebug() << "parsing " << s.toUtf8().data() << "*";
+    qDebug() << "parsing" << s.toUtf8().data() << "*";
     QStringList Args(s.split(',',QString::SkipEmptyParts));
     for (int i=0; i<Args.count(); ++i)
     {

--- a/src/ImportExport/ImportExportGdal.cpp
+++ b/src/ImportExport/ImportExportGdal.cpp
@@ -459,12 +459,12 @@ bool ImportExportGdal::importGDALDataset(GDALDataset* poDS, Layer* aLayer, bool 
             }
             else
             {
-                qDebug( "no geometry\n" );
+                qDebug( "no geometry" );
             }
 //            if (progress.maximum() != 0)
 //                progress.setValue(progress.value()+1);
         }
-        qDebug() << "Layer #" << l << " Features#: " << curImported;
+        qDebug() << "Layer #" << l << "Features#:" << curImported;
     }
 
     pointHash.clear();
@@ -494,7 +494,7 @@ bool ImportExportGdal::import(Layer* aLayer)
 #endif
 
     if( poDS == NULL ) {
-        //qDebug() << "GDAL Open failed from file " << FileName.toUtf8().constData();
+        //qDebug() << "GDAL Open failed from file" << FileName.toUtf8().constData();
         return false;
     }
 
@@ -522,7 +522,7 @@ bool ImportExportGdal::import(Layer* aLayer, const QByteArray& ba, bool confirmP
 
     if( poDS == NULL )
     {
-        qDebug( "GDAL Open failed.\n" );
+        qDebug( "GDAL Open failed." );
         return false;
     }
     importGDALDataset(poDS, aLayer, confirmProjection);

--- a/src/ImportExport/ImportExportOSC.cpp
+++ b/src/ImportExport/ImportExportOSC.cpp
@@ -82,7 +82,7 @@ bool ImportExportOSC::import(Layer* aLayer)
                     F = Relation::fromXML(theDoc, aLayer, stream);
                     theList->add(new AddFeatureCommand(aLayer, F, true));
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "OSC: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "OSC: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     stream.skipCurrentElement();
                 }
                 if (F) {
@@ -120,7 +120,7 @@ bool ImportExportOSC::import(Layer* aLayer)
                     F = Relation::fromXML(theDoc, aLayer, stream);
                     theList->add(new AddFeatureCommand(aLayer, F, true));
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "OSC: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "OSC: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     stream.skipCurrentElement();
                 }
                 if (F) {
@@ -144,7 +144,7 @@ bool ImportExportOSC::import(Layer* aLayer)
                     Relation* R = Relation::fromXML(theDoc, aLayer, stream);
                     theList->add(new RemoveFeatureCommand(theDoc, R));
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "OSC: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "OSC: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     stream.skipCurrentElement();
                 }
                 stream.readNext();

--- a/src/ImportExport/ImportOSM.cpp
+++ b/src/ImportExport/ImportOSM.cpp
@@ -106,7 +106,7 @@ void OSMHandler::parseNode(const QXmlAttributes& atts)
                 NewFeature = false;
             }
         } else {
-            qDebug() << "Node conflicted, but already is tagged as Feature::UserResolved. Ignoring " << Pt->xmlId();
+            qDebug() << "Node conflicted, but already is tagged as Feature::UserResolved. Ignoring" << Pt->xmlId();
             g_backend.deallocFeature(theLayer, Pt);
             Pt = userPt;
             NewFeature = false;

--- a/src/Layers/ImageMapLayer.cpp
+++ b/src/Layers/ImageMapLayer.cpp
@@ -462,7 +462,7 @@ ImageMapLayer * ImageMapLayer::fromXML(Document* d, QXmlStreamReader& stream, QP
                     l->p->AlignementTransformList[z] = QTransformFomXml(stream);
                     stream.readNext();
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "ImgLay: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "ImgLay: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     stream.skipCurrentElement();
                 }
                 stream.readNext();
@@ -481,7 +481,7 @@ ImageMapLayer * ImageMapLayer::fromXML(Document* d, QXmlStreamReader& stream, QP
             if (l->getMapAdapter())
                 l->getMapAdapter()->fromXML(stream);
         } else if (!stream.isWhitespace()) {
-            qDebug() << "ImgLay: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "ImgLay: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
         stream.readNext();
@@ -652,10 +652,10 @@ void ImageMapLayer::draw(MapView& theView, QRect& rect)
     const QSize ps = p->pr.size();
     const QSize pmSize = p->newPix.size();
     const qreal ratio = qMax<const qreal>((qreal)pmSize.width()/ps.width()*1.0, (qreal)pmSize.height()/ps.height()*1.0);
-//    qDebug() << "Bg image ratio " << ratio;
+//    qDebug() << "Bg image ratio" << ratio;
     QPixmap pms;
     if (ratio >= 1.0) {
-//        qDebug() << "Bg image scale 1 " << ps << " : " << p->newPix.size();
+//        qDebug() << "Bg image scale 1" << ps << ":" << p->newPix.size();
         pms = p->newPix.scaled(ps);
     } else {
         const QSizeF drawingSize = pmSize * ratio;
@@ -663,7 +663,7 @@ void ImageMapLayer::draw(MapView& theView, QRect& rect)
         const QPointF drawingOrigin = QPointF(originSize.width(), originSize.height());
         const QRect drawingRect = QRect(drawingOrigin.toPoint(), drawingSize.toSize());
 
-//        qDebug() << "Bg image scale 2 " << ps << " : " << p->newPix.size();
+//        qDebug() << "Bg image scale 2" << ps << ":" << p->newPix.size();
         if (ps*ratio != drawingRect.size())
             pms = p->newPix.copy(drawingRect).scaled(ps*ratio);
         else
@@ -762,7 +762,7 @@ QRect ImageMapLayer::drawFull(MapView& theView, QRect& rect)
         } else if (p->theMapAdapter->getType() == IMapAdapter::NetworkDataBackground) {
 //            QString url (p->theMapAdapter->getQuery(wgs84vp, vp, rect));
 //            if (!url.isEmpty()) {
-//                qDebug() << "ImageMapLayer::drawFull: getting: " << url;
+//                qDebug() << "ImageMapLayer::drawFull: getting:" << url;
 //                QByteArray ba = p->theMapAdapter->getImageManager()->getData(p->theMapAdapter,url);
 //                QDomDocument* theXmlDoc = new QDomDocument();
 //                theXmlDoc->setContent(ba);
@@ -822,7 +822,7 @@ QRect ImageMapLayer::drawFull(MapView& theView, QRect& rect)
         } else if (p->theMapAdapter->getType() == IMapAdapter::NetworkBackground || p->theMapAdapter->getType() == IMapAdapter::BrowserBackground) {
             QString url (p->theMapAdapter->getQuery(wgs84vp, vp, rect));
             if (!url.isEmpty()) {
-                //qDebug() << "ImageMapLayer::drawFull: getting: " << url;
+                //qDebug() << "ImageMapLayer::drawFull: getting:" << url;
                 QPixmap pm = QPixmap::fromImage(p->theMapAdapter->getImageManager()->getImage(p->theMapAdapter,url));
                 if (!pm.isNull()) {
                     p->curPix = QPixmap();
@@ -918,11 +918,11 @@ QRect ImageMapLayer::drawTiled(MapView& theView, QRect& rect)
     QPointF vpCenter0 = QPointF(vpCenter.x()-p->theMapAdapter->getBoundingbox().left(), p->theMapAdapter->getBoundingbox().bottom()-vpCenter.y());
     qreal mapmiddle_tile_x = qRound(vpCenter0.x()/tileWidth);
     qreal mapmiddle_tile_y = qRound(vpCenter0.y()/tileHeight);
-    //qDebug() << "z: " << p->theMapAdapter->getAdaptedZoom() << "; t_x: " << mapmiddle_tile_x << "; t_y: " << mapmiddle_tile_y ;
+    //qDebug() << "z:" << p->theMapAdapter->getAdaptedZoom() << "; t_x:" << mapmiddle_tile_x << "; t_y:" << mapmiddle_tile_y ;
 
     qreal cross_x = vpCenter0.x() - mapmiddle_tile_x*tileWidth;		// position on middle tile
     qreal cross_y = vpCenter0.y() - mapmiddle_tile_y*tileHeight;
-    //qDebug() << "cross_x: " << cross_x << "; cross_y: " << cross_y;
+    //qDebug() << "cross_x:" << cross_x << "; cross_y:" << cross_y;
 
         // calculate how many surrounding tiles have to be drawn to fill the display
     qreal space_left = vp0Center.x() - cross_x;
@@ -954,7 +954,7 @@ QRect ImageMapLayer::drawTiled(MapView& theView, QRect& rect)
     QPainter painter(&p->newPix);
 //    painter.drawPixmap(0, 0, tmpPm);
 
-//    qDebug() << "Tiles: " << tiles_right+tiles_left+1 << "x" << tiles_bottom+tiles_above+1;
+//    qDebug() << "Tiles:" << tiles_right+tiles_left+1 << "x" << tiles_bottom+tiles_above+1;
     for (i=-tiles_left; i<=tiles_right; i++)
     {
         for (j=-tiles_above; j<=tiles_bottom; j++)
@@ -989,10 +989,10 @@ QRect ImageMapLayer::drawTiled(MapView& theView, QRect& rect)
     }
     painter.end();
 
-//    qDebug() << "tl: " << tl << "; br: " << br;
-//    qDebug() << "vp: " << projVp;
-    //    qDebug() << "vlm: " << vlm;
-    //qDebug() << "retRect: " << retRect;
+//    qDebug() << "tl:" << tl << "; br:" << br;
+//    qDebug() << "vp:" << projVp;
+    //    qDebug() << "vlm:" << vlm;
+    //qDebug() << "retRect:" << retRect;
 //    QRect expR = QRect(-retRect.left(), -retRect.top(), retRect.width()+retRect.left(), retRect.height()+retRect.top());
 //    p->newPix.save("c:/tmp.png");
 //    p->newPix.copy(expR).save("c:/tmp2.png");

--- a/src/Layers/Layer.cpp
+++ b/src/Layers/Layer.cpp
@@ -572,7 +572,7 @@ DrawingLayer * DrawingLayer::doFromXML(DrawingLayer* l, Document* d, QXmlStreamR
                 } else if (stream.name() == "bound") {
                     stream.skipCurrentElement();
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "osm: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "osm: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     QString el = stream.readElementText(QXmlStreamReader::IncludeChildElements);
                 }
 
@@ -597,7 +597,7 @@ DrawingLayer * DrawingLayer::doFromXML(DrawingLayer* l, Document* d, QXmlStreamR
             } else
                 stream.skipCurrentElement();
         } else if (!stream.isWhitespace()) {
-            qDebug() << "DrLayer: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "DrLayer: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
 
@@ -792,7 +792,7 @@ TrackLayer * TrackLayer::fromXML(Document* d, QXmlStreamReader& stream, QProgres
                     //l->add(N);
                     progress->setValue(progress->value()+1);
                 } else if (!stream.isWhitespace()) {
-                    qDebug() << "gpx: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                    qDebug() << "gpx: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                     stream.skipCurrentElement();
                 }
 
@@ -805,7 +805,7 @@ TrackLayer * TrackLayer::fromXML(Document* d, QXmlStreamReader& stream, QProgres
                 qApp->processEvents();
             }
         } else if (!stream.isWhitespace()) {
-            qDebug() << "TrLayer: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "TrLayer: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -51,7 +51,7 @@ void showHelp()
 }
 
 void loadPluginsFromDir( QDir & pluginsDir ) {
-    qDebug() << "Loading plugins from directory " << pluginsDir.dirName();
+    qDebug() << "Loading plugins from directory" << pluginsDir.dirName();
     foreach (QString fileName, pluginsDir.entryList(QDir::Files)) {
         QPluginLoader loader(pluginsDir.absoluteFilePath(fileName));
         QObject *plugin = loader.instance();
@@ -60,12 +60,12 @@ void loadPluginsFromDir( QDir & pluginsDir ) {
             IMapAdapterFactory *fac = qobject_cast<IMapAdapterFactory *>(plugin);
             if (fac) {
                 M_PREFS->addBackgroundPlugin(fac);
-                qDebug() << "  Plugin loaded: " << fileName << ".";
+                qDebug() << "  Plugin loaded:" << fileName;
             } else {
-                qWarning() << "  Failed to load plugin: " << fileName << ".";
+                qWarning() << "  Failed to load plugin:" << fileName;
             }
         } else {
-            qWarning() << "  Not a plugin: " << fileName << ".";
+            qWarning() << "  Not a plugin:" << fileName;
         }
     }
 }
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
         pLogFile = fopen(logFilename.toLatin1(), "a");
     /* FIXME: use the file for logging. */
 
-    qDebug() << "**** " << QDateTime::currentDateTime().toString(Qt::ISODate) << " -- Starting " << QString("%1 %2").arg(qApp->applicationName()).arg(STRINGIFY(VERSION));
+    qDebug() << "**** " << QDateTime::currentDateTime().toString(Qt::ISODate) << " -- Starting" << QString("%1 %2").arg(qApp->applicationName()).arg(STRINGIFY(VERSION));
     qDebug() <<	"-------" << QString("using Qt version %1 (built with %2)").arg(qVersion()).arg(QT_VERSION_STR);
     QString projVer = QString(STRINGIFY(PJ_VERSION));
     qDebug() <<	"-------" << QString("using PROJ4 version %1.%2.%3").arg(projVer.left(1)).arg(projVer.mid(1, 1)).arg(projVer.right(1));
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
         x = 255;
     }
 
-    qDebug() << "**** " << QDateTime::currentDateTime().toString(Qt::ISODate) << " -- Ending " << QString("%1 %2").arg(qApp->applicationName()).arg(STRINGIFY(VERSION));
+    qDebug() << "**** " << QDateTime::currentDateTime().toString(Qt::ISODate) << " -- Ending" << QString("%1 %2").arg(qApp->applicationName()).arg(STRINGIFY(VERSION));
     if(pLogFile) {
         fclose(pLogFile);
         pLogFile = NULL;

--- a/src/NameFinder/httpquery.cpp
+++ b/src/NameFinder/httpquery.cpp
@@ -65,7 +65,7 @@ namespace NameFinder
         url.setEncodedQuery(myService.encodedQuery());
 #endif
 
-        qDebug() << "HttpQuery: getting " << url;
+        qDebug() << "HttpQuery: getting" << url;
         QNetworkRequest req(url);
 
         req.setRawHeader(QByteArray("User-Agent"), USER_AGENT.toLatin1());
@@ -83,7 +83,7 @@ namespace NameFinder
                 qDebug() << "HttpQuery: request completed without error.";
                 emit done(reply);
             } else {
-                qDebug() << "HttpQuery: request returned with error " << reply->error() << ": " << reply->errorString();
+                qDebug() << "HttpQuery: request returned with error" << reply->error() << ":" << reply->errorString();
                 emit doneWithError(reply->error());
             }
         } else {

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -386,7 +386,7 @@ void MerkaartorPreferences::on_authenticationRequired( QNetworkReply *reply, QAu
 
 void MerkaartorPreferences::on_sslErrors(QNetworkReply *reply, const QList<QSslError>& errors) {
     Q_UNUSED(reply);
-    qDebug() << "We stumbled upon some SSL errors: ";
+    qDebug() << "We stumbled upon some SSL errors:";
     foreach ( QSslError error, errors ) {
         qDebug() << "1:";
         qDebug() << error.errorString();
@@ -397,7 +397,7 @@ void MerkaartorPreferences::on_requestFinished ( QNetworkReply *reply )
 {
     int error = reply->error();
     if (error != QNetworkReply::NoError) {
-        //qDebug() << "Received response with code " << error << "(" << reply->errorString() << ")";
+        //qDebug() << "Received response with code" << error << "(" << reply->errorString() << ")";
         switch (error) {
             case QNetworkReply::HostNotFoundError:
                 qWarning() << "MerkaartorPreferences: Host not found, preferences won't be synchronized with your profile.";
@@ -466,7 +466,7 @@ void MerkaartorPreferences::on_requestFinished ( QNetworkReply *reply )
 
     QDomElement docElem = theXmlDoc.documentElement();
     if (docElem.tagName() != "MerkaartorLists") {
-        qDebug() << "Invalid OSM Prefs XML root element: " << docElem.tagName();
+        qDebug() << "Invalid OSM Prefs XML root element:" << docElem.tagName();
         return;
     }
 
@@ -504,7 +504,7 @@ void MerkaartorPreferences::on_requestFinished ( QNetworkReply *reply )
 
 void MerkaartorPreferences::putOsmPref(const QString& k, const QString& v)
 {
-    qDebug() << "Saving OSM preference online: " << k << "=" << v;
+    qDebug() << "Saving OSM preference online:" << k << "=" << v;
     QUrl osmWeb(getOsmApiUrl()+QString("/user/preferences/%1").arg(k));
 
     QByteArray ba(v.toUtf8());
@@ -518,7 +518,7 @@ void MerkaartorPreferences::putOsmPref(const QString& k, const QString& v)
 
 void MerkaartorPreferences::deleteOsmPref(const QString& k)
 {
-    qDebug() << "Deleting OSM preference online: " << k;
+    qDebug() << "Deleting OSM preference online:" << k;
 
     QUrl osmWeb(getOsmApiUrl()+QString("/user/preferences/%1").arg(k));
 
@@ -1309,7 +1309,7 @@ QNetworkProxy MerkaartorPreferences::getProxy(const QUrl & requestUrl)
                     theProxy.setPort(proxyUrl.port());
                     theProxy.setUser(proxyUrl.userName());
                     theProxy.setPassword(proxyUrl.password());
-                    //qDebug() << "Using proxy " << proxyUrl << " from libproxy for " << requestUrl;
+                    //qDebug() << "Using proxy" << proxyUrl << "from libproxy for" << requestUrl;
                 }
             }
             for (int i=0 ; proxies[i] ; i++) {
@@ -1389,10 +1389,11 @@ void MerkaartorPreferences::loadProjectionsFromFile(QString fileName)
     if (QDir::isRelativePath(fileName))
         fileName = QCoreApplication::applicationDirPath() + "/" + fileName;
 
-    qDebug() << "loadProjection " << fileName;
+    qDebug() << "loadProjection" << fileName;
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
 //      QMessageBox::critical(this, tr("Invalid file"), tr("%1 could not be opened.").arg(fileName));
+        qDebug() << "  missing";
         return;
     }
 
@@ -1400,6 +1401,7 @@ void MerkaartorPreferences::loadProjectionsFromFile(QString fileName)
     if (!theXmlDoc.setContent(&file)) {
 //		QMessageBox::critical(this, tr("Invalid file"), tr("%1 is not a valid XML file.").arg(fileName));
         file.close();
+        qDebug() << "  not proper XML";
         return;
     }
     file.close();
@@ -1413,7 +1415,7 @@ void MerkaartorPreferences::loadProjections()
 {
     const QStringList paths = getPreferenceFilePaths("Projections.xml");
     for (QStringList::const_iterator i = paths.begin(); i != paths.end(); ++i) {
-	loadProjectionsFromFile(*i);
+        loadProjectionsFromFile(*i);
     }
 }
 
@@ -1442,15 +1444,17 @@ void MerkaartorPreferences::loadFiltersFromFile(QString fileName)
     if (QDir::isRelativePath(fileName))
         fileName = QCoreApplication::applicationDirPath() + "/" + fileName;
 
-    qDebug() << "loadFiltersFromFile " << fileName;
+    qDebug() << "loadFiltersFromFile" << fileName;
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
+        qDebug() << "  missing";
         return;
     }
 
     QDomDocument theXmlDoc;
     if (!theXmlDoc.setContent(&file)) {
         file.close();
+        qDebug() << "  not proper XML";
         return;
     }
     file.close();

--- a/src/Preferences/TMSPreferencesDialog.cpp
+++ b/src/Preferences/TMSPreferencesDialog.cpp
@@ -241,7 +241,7 @@ void TMSPreferencesDialog::on_btGetServices_clicked()
 
 QNetworkReply* TMSPreferencesDialog::sendRequest(QUrl url)
 {
-    qDebug() << "TMS: Sending request to " << url;
+    qDebug() << "TMS: Sending request to" << url;
     QNetworkRequest req(url);
     req.setRawHeader(QByteArray("User-Agent"), USER_AGENT.toLatin1());
 
@@ -282,7 +282,7 @@ void TMSPreferencesDialog::httpRequestFinished( QNetworkReply *reply)
     if (reply->error()) {
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             QMessageBox::critical(this, tr("Merkaartor: GetServices"), tr("Error reading services. The server probably does not support this feature.\n"), QMessageBox::Ok);
-            qDebug() << "TMS GetServices error: " << reply->errorString();
+            qDebug() << "TMS GetServices error:" << reply->errorString();
         }
         return;
     }

--- a/src/QMapControl/browserimagemanager.cpp
+++ b/src/QMapControl/browserimagemanager.cpp
@@ -66,7 +66,7 @@ void BrowserWebPage::javaScriptAlert ( const QString & msg )
         brlat = tokens[3].toDouble();
         brlon = tokens[4].toDouble();
 
-        qDebug() << "Coord: " << tllat << ", " << tllon << ", " << brlat << "," << brlon;
+        qDebug() << "Coord:" << tllat << "," << tllon << "," << brlat << "," << brlon;
     } else
     if (msg.startsWith("Size")) {
 
@@ -82,12 +82,12 @@ void BrowserWebPage::javaScriptAlert ( const QString & msg )
         x1 = int(tokens[3].toDouble());
         y1 = int(tokens[4].toDouble());
 
-        qDebug() << "Size: " << ox << ", " << oy << ", " << x1 << "," << y1;
+        qDebug() << "Size:" << ox << "," << oy << "," << x1 << "," << y1;
 
         sw = x1 - ox;
         sh = y1 - oy;
 
-        qDebug() << "---- " << sw << ", " << sh;
+        qDebug() << "----" << sw << "," << sh;
 
     }
     if (msg.startsWith("ReqSize")) {
@@ -98,13 +98,13 @@ void BrowserWebPage::javaScriptAlert ( const QString & msg )
         w = int(tokens[1].toDouble());
         h = int(tokens[2].toDouble());
 
-        qDebug() << "ReqSize: " << w << ", " << h ;
+        qDebug() << "ReqSize:" << w << "," << h ;
     }
 }
 
 void BrowserWebPage::launchRequest ( const QUrl & url )
 {
-    qDebug() << "Warning: you are using BrowserWebPage to render background imagery. "<<
+    qDebug() << "Warning: you are using BrowserWebPage to render background imagery. "
         "This code is not tested and may not work as expected. If you experience issues, please let us know.";
     sw = sh = 0;
     load(url);
@@ -215,7 +215,7 @@ void BrowserImageManager::launchRequest()
         return;
 //	LoadingRequest* R = loadingRequests.dequeue();
     LoadingRequest R = loadingRequests.head();
-    qDebug() << "BrowserImageManager::launchRequest: " << QString(R.host).append(R.url) << " Hash: " << R.hash;
+    qDebug() << "BrowserImageManager::launchRequest:" << QString(R.host).append(R.url) << "Hash:" << R.hash;
 
     QUrl u = QUrl( R.url);
 
@@ -241,7 +241,7 @@ void BrowserImageManager::pageLoadFinished(bool ok)
     requestActive = false;
 
     if (ok && page->sw && page->sh) {
-        qDebug() << "BrowserImageManager::pageLoadFinished: " << " Hash: " << R.hash;
+        qDebug() << "BrowserImageManager::pageLoadFinished:" << " Hash:" << R.hash;
         QPixmap pt(page->sw, page->sh);
         QPainter P(&pt);
         page->view()->render(&P, QPoint(), QRegion(0,0,page->sw,page->sh));
@@ -272,7 +272,7 @@ void BrowserImageManager::pageLoadFinished(bool ok)
         receivedData(ba, headers, R.hash);
     } else {
         loadingRequests.enqueue(R);
-        qDebug() << "BrowserImageManager::pageLoadFinished - Error: " << " Hash: " << R.hash;
+        qDebug() << "BrowserImageManager::pageLoadFinished - Error:" << "Hash:" << R.hash;
     }
 
     mutex.unlock();

--- a/src/QMapControl/imagemanager.cpp
+++ b/src/QMapControl/imagemanager.cpp
@@ -162,8 +162,8 @@ void ImageManager::loadingQueueEmpty()
 {
     emit(loadingFinished());
 // 	((Layer*)this->parent())->removeZoomImage();
-// 	qDebug() << "size of image-map: " << images.size();
-// 	qDebug() << "size: " << QPixmapCache::cacheLimit();
+// 	qDebug() << "size of image-map:" << images.size();
+// 	qDebug() << "size:" << QPixmapCache::cacheLimit();
 }
 
 void ImageManager::abortLoading()

--- a/src/QMapControl/imagepoint.cpp
+++ b/src/QMapControl/imagepoint.cpp
@@ -22,10 +22,10 @@
 ImagePoint::ImagePoint(double x, double y, QString filename, QString name, Alignment alignment)
  : Point(x, y, name, alignment)
 {
-// 	qDebug() << "loading image: " << filename;
+// 	qDebug() << "loading image:" << filename;
 	mypixmap = new QPixmap(filename);
 	size = mypixmap->size();
-// 	qDebug() << "image size: " << size;
+// 	qDebug() << "image size:" << size;
 }
 
 ImagePoint::ImagePoint(double x, double y, QPixmap* pixmap, QString name, Alignment alignment)

--- a/src/QMapControl/mapcontrol.cpp
+++ b/src/QMapControl/mapcontrol.cpp
@@ -173,7 +173,7 @@ void MapControl::mousePressEvent(QMouseEvent* evnt)
 	
 // 	QMouseEvent* me = new QMouseEvent(evnt->type(), qm.map(QPoint(evnt->x(),evnt->y())), evnt->button(), evnt->buttons(), evnt->modifiers());
 // 	evnt = me;
-// 	qDebug() << "evnt: " << evnt->x() << ", " << evnt->y() << ", " << evnt->pos();
+// 	qDebug() << "evnt:" << evnt->x() << "," << evnt->y() << "," << evnt->pos();
 
 	
 	layermanager->mouseEvent(evnt);

--- a/src/QMapControl/mapnetwork.cpp
+++ b/src/QMapControl/mapnetwork.cpp
@@ -42,7 +42,7 @@ MapNetwork::~MapNetwork()
 
 void MapNetwork::load(const QString& hash, const QString& host, const QString& url)
 {
-    qDebug() << "requesting: " << QString(host).append(url);
+    qDebug() << "requesting:" << QString(host).append(url);
 // 	http->setHost(host);
 // 	int getId = http->get(url);
 
@@ -67,7 +67,7 @@ void MapNetwork::launchRequest()
         theUrl.setUrl("http://" + QString(R->host).append(R->url));
     }
 
-    qDebug() << "getting: " << theUrl.toString();
+    qDebug() << "getting:" << theUrl.toString();
 
     launchRequest(theUrl, R);
 }
@@ -111,27 +111,27 @@ void MapNetwork::requestFinished(QNetworkReply* reply)
 
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->error() != QNetworkReply::OperationCanceledError)
-            qDebug() << "network error: " << statusCode << " " << reply->errorString();
+            qDebug() << "network error:" << statusCode << reply->errorString();
     } else
         switch (statusCode) {
             case 301:
             case 302:
             case 307:
-                qDebug() << "redirected: " << R->host << R->url;
+                qDebug() << "redirected:" << R->host << R->url;
                 launchRequest(reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl(), new LoadingRequest(R->hash, R->host, R->url));
                 return;
             case 404:
-                qDebug() << "404 error: " << R->host << R->url;
+                qDebug() << "404 error:" << R->host << R->url;
                 break;
             case 500:
-                qDebug() << "500 error: " << R->host << R->url;
+                qDebug() << "500 error:" << R->host << R->url;
                 break;
                 // Redirected
             default:
                 if (statusCode != 200)
-                    qDebug() << "Other http code (" << statusCode << "): "  << R->host << R->url;
+                    qDebug() << "Other http code (" << statusCode << "):"  << R->host << R->url;
                 QString hash = R->hash;
-                // 		qDebug() << "request finished for id: " << id;
+                // 		qDebug() << "request finished for id:" << id;
                 QByteArray ax;
                 QHash<QString, QString> headers;
 
@@ -189,7 +189,7 @@ void MapNetwork::timeout()
         return;
 
     LoadingRequest* R = loadingMap[rply];
-    qDebug() << "MapNetwork::timeout: " << R->host << R->url;
+    qDebug() << "MapNetwork::timeout:" << R->host << R->url;
     loadingMap.remove(rply);
     loadingRequests.enqueue(R);
 

--- a/src/Render/NativeRenderDialog.cpp
+++ b/src/Render/NativeRenderDialog.cpp
@@ -146,7 +146,7 @@ void NativeRenderDialog::renderPreview(QPrinter* printer)
     QPainter P(printer);
     P.setRenderHint(QPainter::Antialiasing);
     QRect theR = printer->pageRect();
-    qDebug() << "Rendering preview to: " << theR;
+    qDebug() << "Rendering preview to:" << theR;
     theR.moveTo(0, 0);
     render(P, theR, options());
 }

--- a/src/Sync/DirtyListExecutorOSC.cpp
+++ b/src/Sync/DirtyListExecutorOSC.cpp
@@ -248,7 +248,7 @@ bool DirtyListExecutorOSC::stop()
                         F->setDirtyLevel(0);
 
                     } else
-                        qDebug() << "Feature not found in diff upload result: " << c.attribute("old_id");
+                        qDebug() << "Feature not found in diff upload result:" << c.attribute("old_id");
 
                     c = c.nextSiblingElement();
                 }

--- a/src/Sync/DownloadOSM.cpp
+++ b/src/Sync/DownloadOSM.cpp
@@ -82,7 +82,7 @@ bool Downloader::go(const QUrl& url) {
 bool Downloader::request(const QString& theMethod, const QUrl& url, const QString& theData) {
     if (Error) return false;
 
-    qDebug() << "Downloader::request: " << url;
+    qDebug() << "Downloader::request:" << url;
 
     netManager.setProxy(M_PREFS->getProxy(url));
     QNetworkRequest req(url);
@@ -117,8 +117,8 @@ bool Downloader::request(const QString& theMethod, const QUrl& url, const QStrin
 
     /* We will log the error, but reporting shall be done at the call site. */
     if (currentReply->error()) {
-        qDebug() << "Downloader::request: received response with code "
-            << currentReply->error() << ", message " << currentReply->errorString();
+        qDebug() << "Downloader::request: received response with code"
+            << currentReply->error() << ", message" << currentReply->errorString();
     }
 
 
@@ -308,7 +308,7 @@ bool downloadOSM(QWidget* aParent, const QUrl& theUrl, const QString& aUser, con
 #endif
     }
     int x = Rcv.resultCode();
-    qDebug() << "DownloadOSM: Received OSM API response code: " << x << ", processing.";
+    qDebug() << "DownloadOSM: Received OSM API response code:" << x << ", processing.";
 
     /** We will parse the error codes and display the appropriate messages. */
     switch (x)

--- a/src/Utils/SlippyMapWidget.cpp
+++ b/src/Utils/SlippyMapWidget.cpp
@@ -501,7 +501,7 @@ void SlippyMapCache::startDownload()
             Queue.erase(Queue.begin());
             QUrl reqUrl(baseUrl);
             reqUrl.setPath(QString("/%1/%2/%3.png").arg(DownloadCoord.Zoom).arg(DownloadCoord.X).arg(DownloadCoord.Y));
-            //qDebug() << "Starting download with url: " << reqUrl;
+            //qDebug() << "Starting download with url:" << reqUrl;
             QNetworkRequest req(reqUrl);
             req.setRawHeader(QByteArray("User-Agent"), USER_AGENT.toLatin1());
             DownloadReply = Download.get(req);

--- a/src/common/Document.cpp
+++ b/src/common/Document.cpp
@@ -266,7 +266,7 @@ Document* Document::fromXML(QString title, QXmlStreamReader& stream, qreal versi
             if (version > 1.0)
                 h = CommandHistory::fromXML(NewDoc, stream, progress);
         } else if (!stream.isWhitespace()) {
-            qDebug() << "Doc: logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+            qDebug() << "Doc: logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
             stream.skipCurrentElement();
         }
 
@@ -951,7 +951,7 @@ Document* Document::getDocumentFromXml(QDomDocument* theXmlDoc)
                     } else if (stream.name() == "node") {
                         Node::fromXML(NewDoc, l, stream);
                     } else if (!stream.isWhitespace()) {
-                        qDebug() << "Doc::clipboard logic error: " << stream.name() << " : " << stream.tokenType() << " (" << stream.lineNumber() << ")";
+                        qDebug() << "Doc::clipboard logic error:" << stream.name() << ":" << stream.tokenType() << "(" << stream.lineNumber() << ")";
                         stream.skipCurrentElement();
                     }
                     stream.readNext();


### PR DESCRIPTION
qDebug inserts spaces between components when using the operator<<() style of debugging. Default on, see QDebug::setAutoInsertSpaces(bool)

This commit removes the effectively double whitespace in debug lines.