### PR TITLE
Proj remove legacy api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ jobs:
         - os: linux
           dist: bionic
           env: QT_REPO=ppa:beineri/opt-qt-5.14.0-bionic QT_PREFIX=514
+        - os: linux
+          dist: focal
+          env: QT_REPO=ppa:beineri/opt-qt-5.15.2-focal QT_PREFIX=515
         - os: osx
           osx_image: xcode11.3
         - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ env:
 jobs:
     include:
         - os: linux
-          dist: trusty
-          env: QT_REPO=ppa:beineri/opt-qt591-trusty QT_PREFIX=59
-        - os: linux
-          dist: bionic
-          env: QT_REPO=ppa:beineri/opt-qt-5.14.0-bionic QT_PREFIX=514
-        - os: linux
           dist: focal
           env: QT_REPO=ppa:beineri/opt-qt-5.15.2-focal QT_PREFIX=515
         - os: osx

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 This is a shortened changelog. See the Git commits for a full list of changes.
+next
+    * CHG: Projection engine no longer enables coordinate wrapping by default.
+    * CHG: Projection no longer guesses some EPSG projections only based on string contained, but rather requires it being an exact match.
 
 v0.18.4
     * FIX: Fixed "Create rectangular building" when panning (issue 125).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(merkaartor)
 
+enable_testing()
+
 message(WARNING "
 
 CMake build is experimental and missing quite a few features (no plugins, no version string, no configurable features, etc...). Please use qmake for production builds.
@@ -194,7 +196,6 @@ src/ImportExport/ExportGPX.cpp
 src/ImportExport/ImportGPX.cpp
 src/ImportExport/ImportExportGdal.cpp
 src/MainWindow.h
-src/Main.cpp
 src/common/UploadMapDialog.ui
 src/common/GotoDialog.ui
 src/common/PropertiesDialog.ui
@@ -395,7 +396,7 @@ interfaces/IMapAdapter.h
 )
 
 # Find the QtWidgets library
-find_package(Qt5 COMPONENTS Svg Network Xml Core Gui Concurrent PrintSupport Widgets CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Svg Network Xml Core Gui Concurrent PrintSupport Widgets Test CONFIG REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(EXIV2 REQUIRED exiv2 gdal proj)
 
@@ -403,35 +404,53 @@ pkg_check_modules(EXIV2 REQUIRED exiv2 gdal proj)
 
 
 # Tell CMake to create the helloworld executable
-add_executable(merkaartor ${merkaartor_SRCS})
+add_executable(merkaartor ${merkaartor_SRCS} src/Main.cpp)
 # Use the Widgets module from Qt 5
-target_link_libraries(merkaartor Qt5::Svg Qt5::Network Qt5::Xml Qt5::Core Qt5::Gui Qt5::Concurrent Qt5::PrintSupport Qt5::Widgets ${EXIV2_LIBRARIES} )
+set(MERKAARTOR_LINK_LIBS Qt5::Svg Qt5::Network Qt5::Xml Qt5::Core Qt5::Gui Qt5::Concurrent Qt5::PrintSupport Qt5::Widgets ${EXIV2_LIBRARIES})
+target_link_libraries(merkaartor ${MERKAARTOR_LINK_LIBS} )
 target_compile_options(merkaartor PUBLIC ${EXIV2_CFLAGS_OTHER})
 install( TARGETS merkaartor RUNTIME DESTINATION bin )
 
-target_include_directories( merkaartor PUBLIC
-${EXIV2_INCLUDE_DIRS}
-${CMAKE_CURRENT_SOURCE_DIR}/interfaces
-${CMAKE_CURRENT_SOURCE_DIR}/include
-${CMAKE_CURRENT_SOURCE_DIR}/src
-${CMAKE_CURRENT_SOURCE_DIR}/src/GPS
-${CMAKE_CURRENT_SOURCE_DIR}/src/Backend
-${CMAKE_CURRENT_SOURCE_DIR}/src/Preferences
-${CMAKE_CURRENT_SOURCE_DIR}/src/Render
-${CMAKE_CURRENT_SOURCE_DIR}/src/PaintStyle
-${CMAKE_CURRENT_SOURCE_DIR}/src/ImportExport
-${CMAKE_CURRENT_SOURCE_DIR}/src/common
-${CMAKE_CURRENT_SOURCE_DIR}/src/Layers
-${CMAKE_CURRENT_SOURCE_DIR}/src/Utils
-${CMAKE_CURRENT_SOURCE_DIR}/src/QToolBarDialog
-${CMAKE_CURRENT_SOURCE_DIR}/src/NameFinder
-${CMAKE_CURRENT_SOURCE_DIR}/src/Interactions
-${CMAKE_CURRENT_SOURCE_DIR}/src/Sync
-${CMAKE_CURRENT_SOURCE_DIR}/src/Docks
-${CMAKE_CURRENT_SOURCE_DIR}/src/Features
-${CMAKE_CURRENT_SOURCE_DIR}/src/Commands
-${CMAKE_CURRENT_SOURCE_DIR}/src/qextserialport
-${CMAKE_CURRENT_SOURCE_DIR}/src/QMapControl
-${CMAKE_CURRENT_SOURCE_DIR}/src/TagTemplate
-${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/qtsingleapplication-2.6_1-opensource/src
-    )
+set(MERKAARTOR_INCLUDE_DIRECTORIES
+  ${EXIV2_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/interfaces
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/GPS
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Backend
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Preferences
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Render
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/PaintStyle
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/ImportExport
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Layers
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/QToolBarDialog
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/NameFinder
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Interactions
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Sync
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Docks
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Features
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Commands
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/qextserialport
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/QMapControl
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/TagTemplate
+  ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/qtsingleapplication-2.6_1-opensource/src
+)
+
+target_include_directories( merkaartor PUBLIC ${MERKAARTOR_INCLUDE_DIRECTORIES})
+
+
+##############################################
+# Only test handling goes here
+##############################################
+
+# The test shall be placed in file "tests/<test_name>.cpp" file, followed by required includes
+function(MERK_ADD_TEST test_name)
+  add_executable(${test_name} tests/${test_name}.cpp ${ARGN})
+  target_link_libraries(${test_name} ${MERKAARTOR_LINK_LIBS} Qt5::Test )
+  add_test(${test_name} ${test_name})
+  target_include_directories(${test_name} PUBLIC ${MERKAARTOR_INCLUDE_DIRECTORIES})
+endfunction()
+
+MERK_ADD_TEST(test-projection src/common/Projection.cpp src/common/Coord.cpp)

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -23,8 +23,8 @@ If this is not enough, here are more detailed instructions:
 You will need the following packages installed:
 
  - Working C++ compiler
- - Qt 4.x (4.4.0 or newer) or Qt 5.x (5.3.1 or later)
- - Proj.4
+ - Qt 5.9 or newer
+ - Proj 6.x or newer
  - GDAL (2.0.0 or newer for GDAL exports)
  - Exiv2 (for geoimage support)
  - (For Windows Installer) NSIS-3
@@ -37,13 +37,7 @@ Install the above packages using your package manager. For Debian/Ubuntu, this w
 look like this:
 
 ```
- $ sudo apt-get install build-essential libgdal-dev libproj-dev
-```
-
-For Qt4:
-
-```
- $ sudo apt-get install qt4-default libqt4-xml libqt4-network libqt4-gui libqt4-svg libqt4-webkit libqt4-dev qt4-qmake
+ $ sudo apt-get install build-essential libgdal-dev libproj-dev libexiv2-dev
 ```
 
 Or for Qt5: 

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -11,4 +11,3 @@ fi
 sudo apt-add-repository -y ${QT_REPO}
 sudo apt-get update -qq
 sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}tools qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
-qtchooser -list-versions

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -10,5 +10,5 @@ if [ "${TRAVIS_DIST}" == trusty ]; then
 fi
 sudo apt-add-repository -y ${QT_REPO}
 sudo apt-get update -qq
-sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}-meta-minimal qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
+sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
 qtchooser -list-versions

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -10,5 +10,5 @@ if [ "${TRAVIS_DIST}" == trusty ]; then
 fi
 sudo apt-add-repository -y ${QT_REPO}
 sudo apt-get update -qq
-sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
+sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}tools qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
 qtchooser -list-versions

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -5,9 +5,6 @@ set -ev
 env
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1397BC53640DB551
 sudo echo "deb http://archive.ubuntu.com/ubuntu ${TRAVIS_DIST} main universe restricted multiverse" \> /etc/apt/sources.list
-if [ "${TRAVIS_DIST}" == trusty ]; then
-	sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa
-fi
 sudo apt-add-repository -y ${QT_REPO}
 sudo apt-get update -qq
 sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}tools qt${QT_PREFIX}svg build-essential libgl1-mesa-dev cmake git libexiv2-dev

--- a/ci/travis-linux-install.sh
+++ b/ci/travis-linux-install.sh
@@ -10,4 +10,4 @@ if [ "${TRAVIS_DIST}" == trusty ]; then
 fi
 sudo apt-add-repository -y ${QT_REPO}
 sudo apt-get update -qq
-sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}tools qt${QT_PREFIX}svg build-essential libgl1-mesa-dev
+sudo apt-get -y install gdb libgdal-dev libproj-dev qt${QT_PREFIX}base qt${QT_PREFIX}tools qt${QT_PREFIX}svg build-essential libgl1-mesa-dev cmake git libexiv2-dev

--- a/ci/travis-linux-script.sh
+++ b/ci/travis-linux-script.sh
@@ -4,6 +4,7 @@ source /opt/qt${QT_PREFIX}/bin/qt${QT_PREFIX}-env.sh
 
 set -ev
 
-#qtchooser -qt=qt$QT -run-tool=qmake
-qmake
+mkdir build && cd build
+cmake ..
 make -j3
+QT_QPA_PLATFORM=offscreen ctest --verbose

--- a/ci/travis-windows-script.sh
+++ b/ci/travis-windows-script.sh
@@ -3,7 +3,7 @@
 set -e
 
 qmake.exe -r
-make -j8 release
+make -j4 release
 
 lrelease src/src.pro
 sh windows/copydeps.sh

--- a/interfaces/IProjection.h
+++ b/interfaces/IProjection.h
@@ -10,7 +10,7 @@ public:
     virtual ~IProjection(void) {};
 
     virtual QPointF project(const QPointF& pt) const = 0;
-    virtual QPointF inverse2Point(const QPointF& pt) const = 0;
+    virtual QPointF inverse(const QPointF& pt) const = 0;
 
     virtual QString getProjectionType() const = 0;
 };

--- a/src/Features/Node.cpp
+++ b/src/Features/Node.cpp
@@ -373,7 +373,8 @@ QString Node::toHtml()
 
     if ((i = findKey("_waypoint_")) != -1)
         D += "<p><b>"+QApplication::translate("MapFeature", "Waypoint")+"</b><br/>";
-    D += "<i>"+QApplication::translate("MapFeature", "coord")+": </i>" + COORD2STRING(position().y()) + " (" + Coord2Sexa(position().y()) + ") / " + COORD2STRING(position().x()) + " (" + Coord2Sexa(position().x()) + ")";
+    D += "<i>"+QApplication::translate("MapFeature", "WGS84 coordinates")+": </i>" + COORD2STRING(position().y()) + " (" + Coord2Sexa(position().y()) + ") / " + COORD2STRING(position().x()) + " (" + Coord2Sexa(position().x()) + ")<br/>";
+    D += "<i>"+QApplication::translate("MapFeature", "Projected coordinates")+": </i>" + COORD2STRING(projected().y()) + " / " + COORD2STRING(projected().x());
 
     if ((i = findKey("_description_")) != -1)
         D += "<br/><i>"+QApplication::translate("MapFeature", "description")+": </i>" + tagValue(i);

--- a/src/ImportExport/ImportCSVDialog.cpp
+++ b/src/ImportExport/ImportCSVDialog.cpp
@@ -237,7 +237,7 @@ Feature* ImportCSVDialog::generateOSM(Layer* l, QString line)
     if (CSVProjection.projIsLatLong())
         N->setPosition(p);
     else
-        N->setPosition(CSVProjection.inverse2Coord(p));
+        N->setPosition(CSVProjection.inverse(p));
     return N;
 }
 

--- a/src/Layers/ImageMapLayer.cpp
+++ b/src/Layers/ImageMapLayer.cpp
@@ -97,8 +97,8 @@ CoordBox ImageMapLayer::boundingBox()
 
     p->theProjection.setProjectionType(p->theMapAdapter->projection());
     QRectF r = p->theMapAdapter->getBoundingbox();
-    Coord tl = p->theProjection.inverse2Coord(r.topLeft());
-    Coord br = p->theProjection.inverse2Coord(r.bottomRight());
+    Coord tl = p->theProjection.inverse(r.topLeft());
+    Coord br = p->theProjection.inverse(r.bottomRight());
     return CoordBox(tl, br);
 }
 
@@ -691,8 +691,8 @@ QRect ImageMapLayer::drawFull(MapView& theView, QRect& rect)
 
     MapView::transformCalc(p->theTransform, p->theProjection, 0.0, CoordBox(alignedViewport), rect);
 
-    CoordBox cViewport(p->theProjection.inverse2Coord(p->theTransform.inverted().map(fRect.bottomLeft())),
-                     p->theProjection.inverse2Coord(p->theTransform.inverted().map(fRect.topRight())));
+    CoordBox cViewport(p->theProjection.inverse(p->theTransform.inverted().map(fRect.bottomLeft())),
+                     p->theProjection.inverse(p->theTransform.inverted().map(fRect.topRight())));
     CoordBox Viewport = CoordBox(p->AlignementTransformList.at(0).mapRect(cViewport));
     QPointF bl = theView.toView(Viewport.bottomLeft());
     QPointF tr = theView.toView(Viewport.topRight());
@@ -906,8 +906,8 @@ QRect ImageMapLayer::drawTiled(MapView& theView, QRect& rect)
     QPointF vp0Center = QPointF(projVp.width()/2, -projVp.height()/2);
 
     Coord ulCoord, lrCoord;
-    ulCoord = p->theProjection.inverse2Coord(vlm.topLeft());
-    lrCoord = p->theProjection.inverse2Coord(vlm.bottomRight());
+    ulCoord = p->theProjection.inverse(vlm.topLeft());
+    lrCoord = p->theProjection.inverse(vlm.bottomRight());
 
     const QPointF tl = theView.transform().map(theView.projection().project(ulCoord));
     const QPointF br = theView.transform().map(theView.projection().project(lrCoord));

--- a/src/Layers/OsmRenderLayer.cpp
+++ b/src/Layers/OsmRenderLayer.cpp
@@ -96,8 +96,8 @@ public:
         projR.setTop(projR.top()+dlat);
         projR.setRight(projR.right()+dlon);
 
-        Coord tl = p->theProjection.inverse2Coord(projR.topLeft());
-        Coord br = p->theProjection.inverse2Coord(projR.bottomRight());
+        Coord tl = p->theProjection.inverse(projR.topLeft());
+        Coord br = p->theProjection.inverse(projR.bottomRight());
         CoordBox invalidRect(tl, br);
 
         QMap<RenderPriority, QSet <Feature*> > theFeatures;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,10 +9,7 @@
 #include <qtsingleapplication.h>
 #include "MainWindow.h"
 #include "Preferences/MerkaartorPreferences.h"
-#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#endif
-#include "proj_api.h"
+#include "proj.h"
 #include "gdal_version.h"
 #include "Global.h"
 
@@ -140,8 +137,8 @@ int main(int argc, char** argv)
 
     qDebug() << "**** " << QDateTime::currentDateTime().toString(Qt::ISODate) << " -- Starting " << QString("%1 %2").arg(qApp->applicationName()).arg(STRINGIFY(VERSION));
     qDebug() <<	"-------" << QString("using Qt version %1 (built with %2)").arg(qVersion()).arg(QT_VERSION_STR);
-    QString projVer = QString(STRINGIFY(PJ_VERSION));
-    qDebug() <<	"-------" << QString("using PROJ4 version %1.%2.%3").arg(projVer.left(1)).arg(projVer.mid(1, 1)).arg(projVer.right(1));
+    PJ_INFO projVer = proj_info();
+    qDebug() <<	"-------" << QString("using PROJ version %1.%2.%3").arg(projVer.major).arg(projVer.minor).arg(projVer.patch);
     qDebug() <<	"-------" << QString("using GDAL version %1").arg(GDAL_RELEASE_NAME);
     qDebug() << "-------" << "with arguments: " << QCoreApplication::arguments();
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -102,11 +102,7 @@
 #include <locale.h>
 #include <limits.h>
 
-//For About
-#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#endif
-#include "proj_api.h"
+#include "proj.h"
 #include "gdal_version.h"
 
 #include "Utils/SlippyMapWidget.h"
@@ -2103,8 +2099,8 @@ void MainWindow::on_helpAboutAction_triggered()
     dlg.setWindowFlags(dlg.windowFlags() | Qt::MSWindowsFixedSizeDialogHint);
     About.Version->setText(About.Version->text().arg(STRINGIFY(REVISION)));
     About.QTVersion->setText(About.QTVersion->text().arg(qVersion()).arg(QT_VERSION_STR));
-    QString projVer = QString(STRINGIFY(PJ_VERSION));
-    About.Proj4Version->setText(About.Proj4Version->text().arg(QString("%1.%2.%3").arg(projVer.left(1)).arg(projVer.mid(1, 1)).arg(projVer.right(1))));
+    PJ_INFO projVer = proj_info();
+    About.ProjVersion->setText(About.ProjVersion->text().arg(QString("%1.%2.%3").arg(projVer.major).arg(projVer.minor).arg(projVer.patch)));
     About.GdalVersion->setText(About.GdalVersion->text().arg(GDAL_RELEASE_NAME));
 
     QFile ct(":/Utils/CHANGELOG");

--- a/src/common/AboutDialog.ui
+++ b/src/common/AboutDialog.ui
@@ -31,7 +31,7 @@
         <number>-1</number>
        </property>
        <item row="2" column="1">
-        <widget class="QLabel" name="Proj4Version">
+        <widget class="QLabel" name="ProjVersion">
          <property name="styleSheet">
           <string notr="true">QLabel { font-size:small; font-weight:bold; }</string>
          </property>
@@ -91,12 +91,12 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="Proj4VersionLabel">
+        <widget class="QLabel" name="ProjVersionLabel">
          <property name="styleSheet">
           <string notr="true">QLabel { font-size: x-small; font-style: italic; }</string>
          </property>
          <property name="text">
-          <string>PROJ.4 version</string>
+          <string>PROJ version</string>
          </property>
         </widget>
        </item>

--- a/src/common/FeatureManipulations.cpp
+++ b/src/common/FeatureManipulations.cpp
@@ -1658,12 +1658,12 @@ static bool axisAlignPreprocess(/* in */ PropertiesDock *theDock, const Projecti
         Node *n1;
         Node *n2 = theWay->getNode(0);
         QPointF p1;
-        QPointF p2 = proj.project(n2);
+        QPointF p2 = proj.project(n2->position());
         for (int j = 0; j < theWay->size()-1; ++j, ++i) {
             n1 = n2;
             n2 = theWay->getNode(j + 1);
             p1 = p2;
-            p2 = proj.project(n2);
+            p2 = proj.project(n2->position());
             if (n1 == n2 || p1 == p2) {
                 qWarning() << "ERROR: duplicate nodes found during axis align in" << theWay->id().numId;
                 return false;
@@ -1863,7 +1863,7 @@ AxisAlignResult axisAlignRoads(Document* theDocument, CommandList* theList, Prop
             Node *N = theWay->getNode(i);
             if (!dups && node_pos.contains(N) && !(theWay->isClosed() && i == theWay->size()-1))
                 dups = true;
-            node_pos[N] = proj.project(N);
+            node_pos[N] = proj.project(N->position());
         }
     }
 

--- a/src/common/FeatureManipulations.cpp
+++ b/src/common/FeatureManipulations.cpp
@@ -1983,7 +1983,7 @@ AxisAlignResult axisAlignRoads(Document* theDocument, CommandList* theList, Prop
     foreach (Way *theWay, theWays) {
         for (int i = 0; i < theWay->size(); ++i) {
             Node *N = theWay->getNode(i);
-            theList->add(new MoveNodeCommand(N, proj.inverse2Coord(node_pos[N]), theDocument->getDirtyOrOriginLayer(N->layer())));
+            theList->add(new MoveNodeCommand(N, proj.inverse(node_pos[N]), theDocument->getDirtyOrOriginLayer(N->layer())));
         }
     }
     return AxisAlignSuccess;

--- a/src/common/MapView.cpp
+++ b/src/common/MapView.cpp
@@ -514,7 +514,7 @@ void MapView::drawLatLonGrid(QPainter & P)
             continue;
 //        QPoint pt = QPoint(0, p->theTransform.map(parallelLines.at(i).at(0)).y());
         QPoint ptt = pt.toPoint() + QPoint(5, -5);
-        P.drawText(ptt, QString("%1").arg(p->theProjection.inverse2Coord(parallelLines.at(i).at(0)).y(), 0, 'f', 2-prec));
+        P.drawText(ptt, QString("%1").arg(p->theProjection.inverse(parallelLines.at(i).at(0)).y(), 0, 'f', 2-prec));
     }
     for (int i=0; i<medianLines.size(); ++i) {
 
@@ -534,7 +534,7 @@ void MapView::drawLatLonGrid(QPainter & P)
             continue;
 //        QPoint pt = QPoint(p->theTransform.map(medianLines.at(i).at(0)).x(), 0);
         QPoint ptt = pt.toPoint() + QPoint(5, 10);
-        P.drawText(ptt, QString("%1").arg(p->theProjection.inverse2Coord(medianLines.at(i).at(0)).x(), 0, 'f', 2-prec));
+        P.drawText(ptt, QString("%1").arg(p->theProjection.inverse(medianLines.at(i).at(0)).x(), 0, 'f', 2-prec));
     }
 
     P.restore();
@@ -760,7 +760,7 @@ QPoint MapView::toView(Node* aPt) const
 
 Coord MapView::fromView(const QPoint& aPt) const
 {
-    return p->theProjection.inverse2Coord(p->theInvertedTransform.map(QPointF(aPt)));
+    return p->theProjection.inverse(p->theInvertedTransform.map(QPointF(aPt)));
 }
 
 

--- a/src/common/Painting.cpp
+++ b/src/common/Painting.cpp
@@ -160,7 +160,7 @@ void buildPolygonFromRoad(Way *R, Projection const &theProjection, QPolygonF &Po
 {
     for (int i=0; i<R->size(); ++i)
         if (R->getNode(i)->isVisible() && !R->getNode(i)->isVirtual())
-            Polygon.append(theProjection.project(R->getNode(i)));
+            Polygon.append(theProjection.project(R->getNode(i)->position()));
 }
 
 /// draws way with oneway markers

--- a/src/common/Projection.cpp
+++ b/src/common/Projection.cpp
@@ -205,7 +205,11 @@ bool ProjectionBackend::projIsLatLong() const
 #ifndef _MOBILE
 ProjProjection ProjectionBackend::getProjection(QString projString)
 {
-    ProjProjection theProj = pj_init_plus(QString("%1 +over").arg(projString).toLatin1());
+    QString actualString = QString("%1 +over").arg(projString);
+    ProjProjection theProj = pj_init_plus(actualString.toLatin1());
+    if (!theProj) {
+            qDebug() << "Failed to initialize projection" << actualString << "with error:" << proj_errno_string(proj_errno(nullptr));
+    }
     return theProj;
 }
 #endif // _MOBILE
@@ -243,7 +247,7 @@ bool ProjectionBackend::setProjectionType(QString aProjectionType)
     }
     // Hardcode "lat/long " projection
     if (
-            projType.toUpper().contains("EPSG:4326")
+            projType.toUpper() == "EPSG:4326"
             )
     {
         IsLatLong = true;

--- a/src/common/Projection.cpp
+++ b/src/common/Projection.cpp
@@ -153,13 +153,6 @@ CoordBox ProjectionBackend::fromProjectedRectF(const QRectF& Viewport) const
 
 #ifndef _MOBILE
 
-void ProjectionBackend::projTransform(ProjProjection srcdefn,
-                               ProjProjection dstdefn,
-                               long point_count, int point_offset, qreal *x, qreal *y, qreal *z )
-{
-    pj_transform(srcdefn, dstdefn, point_count, point_offset, (double *)x, (double *)y, (double *)z);
-}
-
 void ProjectionBackend::projTransformFromWGS84(long point_count, int point_offset, qreal *x, qreal *y, qreal *z ) const
 {
     pj_transform (theWGS84Proj, theProj, point_count, point_offset, (double *)x, (double *)y, (double *)z);

--- a/src/common/Projection.cpp
+++ b/src/common/Projection.cpp
@@ -24,7 +24,7 @@ ProjectionBackend::ProjectionBackend(QString initProjection, std::function<QStri
 #if defined(Q_OS_WIN)
     QString pdir(QDir::toNativeSeparators(qApp->applicationDirPath() + "/" STRINGIFY(SHARE_DIR) "/proj"));
     const char* proj_dir = pdir.toUtf8().constData();
-    proj_context_set_search_paths(projCtx, 1, &proj_dir);
+    proj_context_set_search_paths(projCtx.get(), 1, &proj_dir);
 #endif // Q_OS_WIN
     projTransform = std::shared_ptr<PJ>(nullptr);
     projMutex = std::shared_ptr<QMutex>(new QMutex());

--- a/src/common/Projection.cpp
+++ b/src/common/Projection.cpp
@@ -206,16 +206,12 @@ bool ProjectionBackend::setProjectionType(QString aProjectionType)
     }
 
 #ifndef _MOBILE
-    try {
-        projProj4 = mapProjectionName(aProjectionType);
-        projTransform = std::shared_ptr<PJ>(getProjection(projProj4), proj_destroy);
-        if (!projTransform) {
-            // Fall back to the EPSG:3857 and return false. getProjection already logged the error into qDebug().
-            projType = "EPSG:3857";
-            IsMercator = true;
-            return false;
-        }
-    } catch (...) {
+    projProj4 = mapProjectionName(aProjectionType);
+    projTransform = std::shared_ptr<PJ>(getProjection(projProj4), proj_destroy);
+    if (!projTransform) {
+        // Fall back to the EPSG:3857 and return false. getProjection already logged the error into qDebug().
+        projType = "EPSG:3857";
+        IsMercator = true;
         return false;
     }
     return (projTransform != NULL || IsLatLong || IsMercator);

--- a/src/common/Projection.cpp
+++ b/src/common/Projection.cpp
@@ -42,30 +42,17 @@ QPointF ProjectionBackend::project(const QPointF & Map) const
 
 QLineF ProjectionBackend::project(const QLineF & Map) const
 {
-    if (IsMercator)
-        return QLineF (mercatorProject(Map.p1()), mercatorProject(Map.p2()));
-    if (IsLatLong)
-        return QLineF (latlonProject(Map.p1()), latlonProject(Map.p2()));
-    return QLineF(projProject(Map.p1()), projProject(Map.p2()));
+    return QLineF(project(Map.p1()), project(Map.p2()));
 }
 
 
-Coord ProjectionBackend::inverse2Coord(const QPointF & projPoint) const
+QPointF ProjectionBackend::inverse(const QPointF & projPoint) const
 {
     if (IsLatLong)
         return latlonInverse(projPoint);
     if (IsMercator)
         return mercatorInverse(projPoint);
     return projInverse(projPoint);
-}
-
-QPointF ProjectionBackend::inverse2Point(const QPointF & Map) const
-{
-    if  (IsLatLong)
-        return latlonInverse(Map);
-    if  (IsMercator)
-        return mercatorInverse(Map);
-    return projInverse(Map);
 }
 
 QRectF ProjectionBackend::toProjectedRectF(const QRectF& Viewport, const QRect& screen) const
@@ -104,8 +91,8 @@ CoordBox ProjectionBackend::fromProjectedRectF(const QRectF& Viewport) const
     Coord tl, br;
     CoordBox bbox;
 
-    tl = inverse2Coord(Viewport.topLeft());
-    br = inverse2Coord(Viewport.bottomRight());
+    tl = inverse(Viewport.topLeft());
+    br = inverse(Viewport.bottomRight());
     bbox = CoordBox(tl, br);
 
     return bbox;

--- a/src/common/Projection.h
+++ b/src/common/Projection.h
@@ -4,20 +4,13 @@
 #include "IProjection.h"
 #include "Coord.h"
 
-#include <QPointF>
-#include <functional>
-
-#ifndef _MOBILE
 #include "MerkaartorPreferences.h"
 
-/* TODO: Proj.4 version 6.0.0 introduces new API changes, but is not widely
- * available yet. Until it is available on most distros, we will keep using the legacy API.
- * A migration will eventually be necessary (more research is needed). */
+
+#include <QPointF>
 #include <proj.h>
-
+#include <functional>
 #include <memory>
-
-#endif // _MOBILE
 
 class QRect;
 class Node;
@@ -26,7 +19,6 @@ class ProjectionBackend : public IProjection
 {
 public:
     ProjectionBackend(QString initProjection, std::function<QString(QString)> mapProjectionName);
-    virtual ~ProjectionBackend(void) {};
 
     qreal latAnglePerM() const;
     qreal lonAnglePerM(qreal Lat) const;
@@ -50,10 +42,8 @@ public:
 
 protected:
     PJ* getProjection(QString projString);
-#ifndef _MOBILE
     QPointF projProject(const QPointF& Map) const;
     Coord projInverse(const QPointF& Screen) const;
-#endif
 
     QString projType;
     QString projProj4;

--- a/src/common/Projection.h
+++ b/src/common/Projection.h
@@ -24,8 +24,7 @@ public:
     qreal lonAnglePerM(qreal Lat) const;
     QLineF project(const QLineF & Map) const;
     QPointF project(const QPointF& Map) const;
-    Coord inverse2Coord(const QPointF& Screen) const;
-    QPointF inverse2Point(const QPointF& Map) const;
+    QPointF inverse(const QPointF& Map) const;
 
     bool setProjectionType(QString aProjectionType);
     QString getProjectionType() const;

--- a/src/common/Projection.h
+++ b/src/common/Projection.h
@@ -13,6 +13,7 @@
 /* TODO: Proj.4 version 6.0.0 introduces new API changes, but is not widely
  * available yet. Until it is available on most distros, we will keep using the legacy API.
  * A migration will eventually be necessary (more research is needed). */
+#include <proj.h>
 #define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
 #include <proj_api.h>
 

--- a/src/common/Projection.h
+++ b/src/common/Projection.h
@@ -15,6 +15,8 @@
  * A migration will eventually be necessary (more research is needed). */
 #include <proj.h>
 
+#include <memory>
+
 #endif // _MOBILE
 
 class QRect;
@@ -24,7 +26,7 @@ class ProjectionBackend : public IProjection
 {
 public:
     ProjectionBackend(QString initProjection, std::function<QString(QString)> mapProjectionName);
-    virtual ~ProjectionBackend(void);
+    virtual ~ProjectionBackend(void) {};
 
     qreal latAnglePerM() const;
     qreal lonAnglePerM(qreal Lat) const;
@@ -74,12 +76,14 @@ protected:
         return Coord(point.x()/*/EQUATORIALMETERPERDEGREE*/, point.y()/*/EQUATORIALMETERPERDEGREE*/);
     }
 private:
-    PJ_CONTEXT* projCtx;
-    PJ* projTransform;
-    QMutex* projMutex; // TODO: projTransform is not thread-safe by itself, so we need to protect it by a mutex.
-                       // In theory, each thread could have it's own projection
-                       // object, but currently the object is copied around.
-                       // Until this changes, the mutex stays here.
+    // Note: keep the order of projCtx and projTransform, as projTransform depends on projCtx.
+    std::shared_ptr<PJ_CONTEXT> projCtx;
+    std::shared_ptr<PJ> projTransform;
+    std::shared_ptr<QMutex> projMutex;
+    // TODO: projTransform is not thread-safe by itself, so we need to protect
+    // it by a mutex.  In theory, each thread could have it's own projection
+    // object, but currently the object is copied around.  Until this changes,
+    // the mutex stays here.
 };
 
 /**

--- a/src/common/Projection.h
+++ b/src/common/Projection.h
@@ -49,10 +49,6 @@ public:
 
 #ifndef _MOBILE
 
-    static ProjProjection getProjection(QString projString);
-    static void projTransform(ProjProjection srcdefn,
-                              ProjProjection dstdefn,
-                              long point_count, int point_offset, qreal *x, qreal *y, qreal *z );
     void projTransformToWGS84(long point_count, int point_offset, qreal *x, qreal *y, qreal *z ) const;
     void projTransformFromWGS84(long point_count, int point_offset, qreal *x, qreal *y, qreal *z ) const;
 
@@ -61,6 +57,7 @@ public:
     void fromXML(QXmlStreamReader& stream);
 
 protected:
+    static ProjProjection getProjection(QString projString);
 #ifndef _MOBILE
     ProjProjection theProj;
     QPointF projProject(const QPointF& Map) const;

--- a/tests/test-projection.cpp
+++ b/tests/test-projection.cpp
@@ -1,0 +1,17 @@
+#include <QtTest/QtTest>
+
+#include "common/Projection.h"
+
+class TestProjection: public QObject
+{
+  Q_OBJECT
+  private slots:
+
+  void projectionInit() {
+    ProjectionBackend proj("XX", [](QString x) {return x;});
+    QVERIFY(true);
+  }
+};
+
+QTEST_MAIN(TestProjection)
+#include "test-projection.moc"

--- a/tests/test-projection.cpp
+++ b/tests/test-projection.cpp
@@ -41,7 +41,7 @@ class TestProjection: public QObject
     };
     for(auto& pair : list) {
       QCOMPARE(proj.project(pair.first), pair.second);
-      //QCOMPARE(proj.inverse2Point(pair.second), pair.first); // TODO: This projection does not seem to converge very well.
+      //QCOMPARE(proj.inverse(pair.second), pair.first); // TODO: This projection does not seem to converge very well.
     }
     QBENCHMARK(proj.project(QPointF(14.4157,50.1038)));
   }
@@ -53,7 +53,7 @@ class TestProjection: public QObject
     ProjectionBackend proj("EPSG:4326", [](QString x) {return x;});
     QPointF point(14.4157,50.1038);
     QCOMPARE(proj.project(point), point);
-    QCOMPARE(proj.inverse2Point(point), point);
+    QCOMPARE(proj.inverse(point), point);
     QBENCHMARK(proj.project(point));
   }
 
@@ -64,7 +64,7 @@ class TestProjection: public QObject
     ProjectionBackend proj("+proj=longlat +datum=WGS84", [](QString x) {return x;});
     QPointF point(14.4157,50.1038);
     QCOMPARE(proj.project(point), point);
-    QCOMPARE(proj.inverse2Point(point), point);
+    QCOMPARE(proj.inverse(point), point);
     QBENCHMARK(proj.project(point));
   }
 
@@ -76,7 +76,7 @@ class TestProjection: public QObject
     QPointF point(14.4157,50.1038);
     QPointF projected(1604748.38320521079,6464271.615268512629);
     QCOMPARE(proj.project(point),  projected);
-    QCOMPARE(proj.inverse2Point(projected), point);
+    QCOMPARE(proj.inverse(projected), point);
     QBENCHMARK(proj.project(point));
   }
 };

--- a/tests/test-projection.cpp
+++ b/tests/test-projection.cpp
@@ -8,8 +8,32 @@ class TestProjection: public QObject
   private slots:
 
   void projectionInit() {
-    ProjectionBackend proj("XX", [](QString x) {return x;});
-    QVERIFY(true);
+    ProjectionBackend proj("EPSG:3857", [](QString x) {return x;});
+    qDebug() << proj.getProjectionType();
+    qDebug() << proj.getProjectionProj4();
+    QCOMPARE(proj.getProjectionType(), "EPSG:3857"); // Would not be set if init failed.
+  }
+
+  /**
+   * This test verifies the Proj4 library is loaded and correctly identifies non-standard projection.
+   */
+  void projectionInitProj4() {
+    ProjectionBackend proj("+init=epsg:5514", [](QString x) {return x;});
+    qDebug() << proj.getProjectionType();
+    qDebug() << proj.getProjectionProj4();
+    QCOMPARE(proj.getProjectionType(), "+init=epsg:5514");
+    QVERIFY(proj.getProjectionProj4().contains("+proj=krovak"));
+  }
+
+
+  /**
+   * This test verifies proj4 library is able to project correctly from WGS84 to a non-standard projection.
+   */
+  void projectionWGS84toEPSG5514() {
+    ProjectionBackend proj("+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=greenwich +units=m +no_defs +towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56", [](QString x) {return x;});
+
+    QCOMPARE(proj.project(QPointF(14.4157,50.1038)), QPointF(-742955.5923625092255,-1041158.8852684112499));
+    QCOMPARE(proj.project(QPointF(18.9816,50.1259)), QPointF(-418013.62494312302442,-1073425.9725897577591));
   }
 };
 

--- a/tests/test-projection.cpp
+++ b/tests/test-projection.cpp
@@ -26,6 +26,11 @@ class TestProjection: public QObject
   }
 
 
+  void projectionWGS84toEPSG3031() {
+    ProjectionBackend proj("+init=epsg:3031", [](QString x) {return x;});
+    qDebug() << proj.getProjectionProj4();
+  }
+
   /**
    * This test verifies proj4 library is able to project correctly from WGS84 to a non-standard projection.
    */
@@ -34,6 +39,37 @@ class TestProjection: public QObject
 
     QCOMPARE(proj.project(QPointF(14.4157,50.1038)), QPointF(-742955.5923625092255,-1041158.8852684112499));
     QCOMPARE(proj.project(QPointF(18.9816,50.1259)), QPointF(-418013.62494312302442,-1073425.9725897577591));
+    QBENCHMARK(proj.project(QPointF(14.4157,50.1038)));
+  }
+
+  /**
+   * Use default "LatLong" projection, which is in fact identity.
+   */
+  void projectionWGS84toLatLong() {
+    ProjectionBackend proj("EPSG:4326", [](QString x) {return x;});
+    QPointF point(14.4157,50.1038);
+    QCOMPARE(proj.project(point), point);
+    QBENCHMARK(proj.project(point));
+  }
+
+  /**
+   * This test uses proj4 to do the identity projection. In process, it converts to radians from decimal degrees.
+   */
+  void projectionWGS84toWGS84() {
+    ProjectionBackend proj("+init=epsg:4326", [](QString x) {return x;});
+    QPointF point(14.4157,50.1038);
+    QCOMPARE(proj.project(point), point*M_PI/180);
+    QBENCHMARK(proj.project(point));
+  }
+
+  /**
+   * Test the internal Mercator projection.
+   */
+  void projectionWGS84toMercator() {
+    ProjectionBackend proj("EPSG:3857", [](QString x) {return x;});
+    QPointF point(14.4157,50.1038);
+    QCOMPARE(proj.project(point),  QPointF(1604748.38320521079,6464271.615268512629));
+    QBENCHMARK(proj.project(point));
   }
 };
 


### PR DESCRIPTION
This PR removes legacy PROJ.4 API and replaces it with v6 API in a compatible manner. Solves issue #193.