### PR TITLE
Dont delete nodes on undo join ways

### DIFF
--- a/src/common/FeatureManipulations.cpp
+++ b/src/common/FeatureManipulations.cpp
@@ -218,7 +218,9 @@ static void appendPoints(Document* theDocument, CommandList* L, Way* Dest, Way* 
     for (int i=1; i<srclen; ++i) {
         int j = (reverse ? srclen-i : i) - (prepend != reverse ? 1 : 0);
         Node* Pt = Src->getNode(j);
-        L->add(new AddFeatureCommand(layer, Pt, false));
+        if (!Pt->layer() || layer != Pt->layer()) {
+            L->add(new AddFeatureCommand(layer, Pt, false));
+        }
         L->add(new WayAddNodeCommand(Dest, Pt, destpos++, layer));
     }
 }


### PR DESCRIPTION
When joining ways and then doing undo AddFeatureCommand deletes nodes if joined ways were not on different layers. This then breaks any uploading to OSM.
This pull request simply doesn't do AddFeatureCommand if ways are not on different layers.