### PR TITLE
Fix osx build

### DIFF
--- a/ci/travis-osx-install.sh
+++ b/ci/travis-osx-install.sh
@@ -26,5 +26,5 @@ brew info cmake
 # build will fail later anyway if something doesn't install properly.
 #brew install Dylibbundler proj exiv2 gdal qt5 || echo "Install might have failed. Ignoring"
 brew install exiv2 || echo "Install might have failed. Ignoring"
-brew upgrade cmake
+brew upgrade cmake proj
 #brew link --force qt5 || echo "Link might have failed. Ignoring."


### PR DESCRIPTION
This PR implements an upgrade in OSX install script to GDAL library. The preinstalled version no longer plays well with recent CMake versions.