### PR TITLE
Fixed an issue where Build Bridge interaction tried to remove non-existent tag.

### DIFF
--- a/src/Commands/FeatureCommands.cpp
+++ b/src/Commands/FeatureCommands.cpp
@@ -311,6 +311,9 @@ ClearTagCommand::ClearTagCommand(Feature* F)
 ClearTagCommand::ClearTagCommand(Feature* F, const QString& k, Layer* aLayer)
 : TagCommand(F, aLayer), theIdx(F->findKey(k)), theK(k), theV(F->tagValue(k, ""))
 {
+    if (theIdx < 0) {
+        qCritical() << "ClearTagCommand required to remove a non-existent tag.";
+    }
     description = QApplication::tr("Remove tag '%1' from %2").arg(k).arg(F->description());
     oldLayer = theFeature->layer();
     redo();

--- a/src/Interactions/BuildBridgeInteraction.cpp
+++ b/src/Interactions/BuildBridgeInteraction.cpp
@@ -123,10 +123,14 @@ void BuildBridgeInteraction::splitAndMark() {
 				layer--;
 			}
 
-			if (layer == 0)
-				theList->add(new ClearTagCommand(R, "layer"));
-			else 
+			if (layer == 0) {
+				/* Remove the layer tag if it exists and would become 0. */
+				if (R->findKey("level") != -1) {
+					theList->add(new ClearTagCommand(R, "layer"));
+				}
+			} else {
 				theList->add(new SetTagCommand(R, "layer", QString::number(layer)));
+			}
 		} else {
 			QMessageBox::critical(g_Merk_MainWindow, tr("BridgeBuilder"), tr("Selected segment is already tagged as bridge/tunnel. Please, make sure you know what you're doing."));
 		}


### PR DESCRIPTION
Re-adding that cause an assert fail on undo. Addition log introduced
into the ClearTagCommand to see if other code eventually hits it, as
there is no way to fail the constructor besides exceptions.