### PR TITLE
Disabled selection of virtual nodes.

### DIFF
--- a/src/Interactions/EditInteraction.cpp
+++ b/src/Interactions/EditInteraction.cpp
@@ -35,10 +35,6 @@ EditInteraction::EditInteraction(MainWindow* aMain)
     connect(main(),SIGNAL(remove_triggered()),this,SLOT(on_remove_triggered()));
     connect(main(),SIGNAL(reverse_triggered()), this,SLOT(on_reverse_triggered()));
     PROPERTIES(checkMenuStatus());
-
-    if (!M_PREFS->getSeparateMoveMode()) {
-        setDontSelectVirtual(false);
-    }
 }
 
 EditInteraction::~EditInteraction(void)


### PR DESCRIPTION
Virtual nodes are not proper nodes and most interactions don't work with
them and cause crashes or weird behavior. The only allowed action for
virtual node is the move interaction.

I am aware of two limitations:
- Unless the option "Use separate move mode" is selected, virtual nodes cannot be moved (as selection is required in the combined mode)
- Multiple virtual nodes cannot be moved at once (though I don't really see a use case for this).

This PR is a workaround for issue identified in PR #240, see more details in discussion to that PR.