### PR TITLE
Cmake unity build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,14 @@ jobs:
     strategy:
       matrix:
         SNAPSHOT: [0, 1]
-    name: Linux / Ubuntu 20.04 / Qt5 (SNAPSHOT=${{ matrix.SNAPSHOT }})
+        CMAKE_UNITY_BUILD: ["ON", "OFF"]
+    name: Linux / Ubuntu 20.04 / Qt5 (SNAPSHOT=${{ matrix.SNAPSHOT }}) / CMAKE_UNITY_BUILD=${{ matrix.CMAKE_UNITY_BUILD }}
     env:
       QT_PREFIX: 515
       QT_REPO: ppa:beineri/opt-qt-5.15.4-focal
       TRAVIS_DIST: focal
       SNAPSHOT: ${{ matrix.SNAPSHOT }}
+      CMAKE_UNITY_BUILD: ${{ matrix.CMAKE_UNITY_BUILD }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -88,9 +90,11 @@ jobs:
     strategy:
       matrix:
         SNAPSHOT: [0, 1]
-    name: Linux / Ubuntu 22.04 / Qt6 (SNAPSHOT=${{ matrix.SNAPSHOT }})
+        CMAKE_UNITY_BUILD: ["ON", "OFF"]
+    name: Linux / Ubuntu 22.04 / Qt6 (SNAPSHOT=${{ matrix.SNAPSHOT }}) / CMAKE_UNITY_BUILD=${{ matrix.CMAKE_UNITY_BUILD }}
     env:
       SNAPSHOT: ${{ matrix.SNAPSHOT }}
+      CMAKE_UNITY_BUILD: ${{ matrix.CMAKE_UNITY_BUILD }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.cpp
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.cpp
@@ -65,16 +65,6 @@ static PProcessIdToSessionId pProcessIdToSessionId = 0;
 #include <unistd.h>
 #include <sys/types.h>
 
-namespace QtLP_Private {
-#include "qtlockedfile.cpp"
-#if defined(Q_OS_WIN)
-#include "qtlockedfile_win.cpp"
-#else
-#include "qtlockedfile_unix.cpp"
-#endif
-}
-
-
 const char* QtLocalPeer::ack = "ack";
 
 QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.h
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.h
@@ -49,9 +49,7 @@
 #include <QtNetwork/QLocalSocket>
 #include <QtCore/QDir>
 
-namespace QtLP_Private {
 #include "qtlockedfile.h"
-}
 
 class QtLocalPeer : public QObject
 {

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.h
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlocalpeer.h
@@ -1,3 +1,4 @@
+#pragma once
 /****************************************************************************
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile.cpp
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile.cpp
@@ -86,6 +86,7 @@
 
     \sa QFile::QFile()
 */
+namespace QtLP_Private {
 QtLockedFile::QtLockedFile()
     : QFile()
 {
@@ -197,3 +198,4 @@ QtLockedFile::LockMode QtLockedFile::lockMode() const
     Destroys the \e QtLockedFile object. If any locks were held, they
     are released.
 */
+}

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile.h
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile.h
@@ -67,6 +67,7 @@
 #else
 #  define QT_QTLOCKEDFILE_EXPORT
 #endif
+namespace QtLP_Private {
 
 class QT_QTLOCKEDFILE_EXPORT QtLockedFile : public QFile
 {
@@ -97,5 +98,5 @@ private:
 #endif
     LockMode m_lock_mode;
 };
-
+}
 #endif

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile_unix.cpp
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile_unix.cpp
@@ -50,6 +50,7 @@
 #include <fcntl.h>
 
 #include "qtlockedfile.h"
+namespace QtLP_Private {
 
 bool QtLockedFile::lock(LockMode mode, bool block)
 {
@@ -119,3 +120,4 @@ QtLockedFile::~QtLockedFile()
         unlock();
 }
 
+}

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile_win.cpp
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile_win.cpp
@@ -54,6 +54,7 @@
 #define MUTEX_PREFIX "QtLockedFile mutex "
 // Maximum number of concurrent read locks. Must not be greater than MAXIMUM_WAIT_OBJECTS
 #define MAX_READERS MAXIMUM_WAIT_OBJECTS
+namespace QtLP_Private {
 
 Qt::HANDLE QtLockedFile::getMutexHandle(int idx, bool doCreate)
 {
@@ -213,4 +214,5 @@ QtLockedFile::~QtLockedFile()
         unlock();
     if (wmutex)
         CloseHandle(wmutex);
+}
 }

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtsingleapplication.h
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtsingleapplication.h
@@ -1,3 +1,4 @@
+#pragma once
 /****************************************************************************
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).

--- a/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtsinglecoreapplication.h
+++ b/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtsinglecoreapplication.h
@@ -1,3 +1,4 @@
+#pragma once
 /****************************************************************************
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).

--- a/ci/travis-linux-script.sh
+++ b/ci/travis-linux-script.sh
@@ -17,6 +17,6 @@ else
 fi
 
 # Note: We need to specify the system cmake, as travis has older version in PATH before the system paths for some reason.
-/usr/bin/cmake .. -DCMAKE_BUILD_TYPE=Release -DEXTRA_TESTS=OFF
+/usr/bin/cmake .. -DCMAKE_BUILD_TYPE=Release -DEXTRA_TESTS=OFF -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD}
 make -j3
 QT_QPA_PLATFORM=offscreen ctest --verbose

--- a/src/Docks/GeoImageDock.h
+++ b/src/Docks/GeoImageDock.h
@@ -1,4 +1,5 @@
 
+#pragma once
 #include "MapView.h"
 #include "MainWindow.h"
 #include "Document.h"

--- a/src/Features/Node.cpp
+++ b/src/Features/Node.cpp
@@ -9,7 +9,7 @@
 #include <QtGui/QPainter>
 #include <QProgressDialog>
 
-#define TEST_RFLAGS(x) theView->renderOptions().options.testFlag(x)
+#define TEST_RFLAGS_NODE(x) theView->renderOptions().options.testFlag(x)
 
 Node::Node(const Coord& aCoord)
     : Feature()
@@ -163,7 +163,7 @@ const CoordBox& Node::boundingBox(bool) const
 
 void Node::drawSimple(QPainter &P, MapView *theView)
 {
-//    if (!M_PREFS->getWireframeView() && !TEST_RFLAGS(RendererOptions::Interacting))
+//    if (!M_PREFS->getWireframeView() && !TEST_RFLAGS_NODE(RendererOptions::Interacting))
 //        return;
 
     if (! ((isReadonly() || !isSelectable(theView->pixelPerM(), theView->renderOptions())) && (!isPOI() && !isWaypoint())))
@@ -725,7 +725,7 @@ void PhotoNode::drawHover(QPainter& thePainter, MapView* theView)
     Feature::drawHover(thePainter, theView);
 
     /* and then the image */
-    if (TEST_RFLAGS(RendererOptions::PhotosVisible) && theView->pixelPerM() > M_PREFS->getRegionalZoom()) {
+    if (TEST_RFLAGS_NODE(RendererOptions::PhotosVisible) && theView->pixelPerM() > M_PREFS->getRegionalZoom()) {
         QPoint me(theView->toView(this));
 
         qreal rt = qBound(0.2, (double)theView->pixelPerM(), 1.0);
@@ -746,7 +746,7 @@ qreal PhotoNode::pixelDistance(const QPointF& Target, qreal ClearDistance, const
 {
 #ifdef GEOIMAGE
     QPoint me = theView->toView(const_cast<PhotoNode*>(this));
-    if (TEST_RFLAGS(RendererOptions::PhotosVisible) && theView->pixelPerM() > M_PREFS->getRegionalZoom()) {
+    if (TEST_RFLAGS_NODE(RendererOptions::PhotosVisible) && theView->pixelPerM() > M_PREFS->getRegionalZoom()) {
         qreal rt = qBound(0.2, (double)theView->pixelPerM(), 1.0);
         qreal phRt = 1. * Photo->width() / Photo->height();
         QPoint phPt;

--- a/src/Features/Relation.cpp
+++ b/src/Features/Relation.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <QList>
 
-#define TEST_RFLAGS(x) theView->renderOptions().options.testFlag(x)
+#define TEST_RFLAGS_RELATION(x) theView->renderOptions().options.testFlag(x)
 
 class RelationMemberModel : public QAbstractTableModel
 {
@@ -250,7 +250,7 @@ qreal Relation::pixelDistance(const QPointF& Target, qreal ClearEndDistance, con
     Q_UNUSED(NoSnap)
 
     qreal Best = 1000000;
-    if (!TEST_RFLAGS(RendererOptions::RelationsVisible) && !M_PREFS->getRelationsSelectableWhenHidden())
+    if (!TEST_RFLAGS_RELATION(RendererOptions::RelationsVisible) && !M_PREFS->getRelationsSelectableWhenHidden())
         return Best;
 
     //for (int i=0; i<p->Members.size(); ++i)

--- a/src/Features/TrackSegment.cpp
+++ b/src/Features/TrackSegment.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <QList>
 
-#define TEST_RFLAGS(x) theView->renderOptions().options.testFlag(x)
+#define TEST_RFLAGS_TRACK_SEGMENT(x) theView->renderOptions().options.testFlag(x)
 
 class TrackSegmentPrivate
 {
@@ -165,7 +165,7 @@ void TrackSegment::drawTouchup(QPainter &P, MapView* theView)
 {
     QPen pen;
 
-    if (!TEST_RFLAGS(RendererOptions::TrackSegmentVisible))
+    if (!TEST_RFLAGS_TRACK_SEGMENT(RendererOptions::TrackSegmentVisible))
         return;
 
     for (int i=1; i<p->Nodes.size(); ++i)

--- a/src/Features/Way.cpp
+++ b/src/Features/Way.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <QList>
 
-#define TEST_RFLAGS(x) theView->renderOptions().options.testFlag(x)
+#define TEST_RFLAGS_WAY(x) theView->renderOptions().options.testFlag(x)
 
 class WayPrivate
 {

--- a/src/Interactions/Interaction.cpp
+++ b/src/Interactions/Interaction.cpp
@@ -21,7 +21,7 @@
 
 #include <math.h>
 
-#define CLEAR_DISTANCE 7.01
+#define CLEAR_DISTANCE_INTERACTION 7.01
 
 Interaction::Interaction(MainWindow* aMain)
     : QObject(aMain), theMain(aMain), Panning(false)
@@ -275,7 +275,7 @@ void FeatureSnapInteraction::updateSnap(QMouseEvent* event)
                         SnapList.push_back(F);
                 }
 
-                qreal Distance = F->pixelDistance(event->pos(), CLEAR_DISTANCE, NoSnap, view());
+                qreal Distance = F->pixelDistance(event->pos(), CLEAR_DISTANCE_INTERACTION, NoSnap, view());
                 if (Distance < BestDistance && !F->isReadonly())
                 {
                     BestDistance = Distance;
@@ -291,7 +291,7 @@ void FeatureSnapInteraction::updateSnap(QMouseEvent* event)
     if (areNodesSelectable) {
         R = CAST_WAY(lastSnap());
         if (R) {
-            Node* N = R->pixelDistanceNode(event->pos(), CLEAR_DISTANCE, view(), NoSnap, NoSelectVirtuals);
+            Node* N = R->pixelDistanceNode(event->pos(), CLEAR_DISTANCE_INTERACTION, view(), NoSnap, NoSelectVirtuals);
             if (N)
                 setLastSnap( N );
         }

--- a/src/Layers/LayerIterator.h
+++ b/src/Layers/LayerIterator.h
@@ -1,3 +1,4 @@
+#pragma once
 class IDocument;
 
 template <class L>

--- a/src/PaintStyle/FeaturePainter.cpp
+++ b/src/PaintStyle/FeaturePainter.cpp
@@ -13,7 +13,7 @@
 #include <QDomElement>
 #include <math.h>
 
-#define TEST_RFLAGS(x) theRenderer->theOptions.options.testFlag(x)
+#define TEST_RFLAGS_FEATURE_PAINTER(x) theRenderer->theOptions.options.testFlag(x)
 #define CAPSTYLE Qt::RoundCap
 #define JOINSTYLE Qt::RoundJoin
 
@@ -705,7 +705,7 @@ void FeaturePainter::drawLabel(Way* R, QPainter* thePainter, MapRenderer* theRen
     LineParameters lp = labelBoundary();
     qreal PixelPerM = theRenderer->thePixelPerM;
     qreal WW = PixelPerM*R->widthOf()*lp.Proportional+lp.Fixed;
-    if (WW < 10 && !TEST_RFLAGS(RendererOptions::PrintAllLabels)) return;
+    if (WW < 10 && !TEST_RFLAGS_FEATURE_PAINTER(RendererOptions::PrintAllLabels)) return;
     //qreal WWR = qMax(PixelPerM*R->widthOf()*BackgroundScale+BackgroundOffset, PixelPerM*R->widthOf()*ForegroundScale+ForegroundOffset);
 
     R->getLock();
@@ -727,7 +727,7 @@ void FeaturePainter::drawLabel(Way* R, QPainter* thePainter, MapRenderer* theRen
         QFontMetricsF metrics(font);
         qreal strWidth = metrics.horizontalAdvance(str);
 
-        if ((font.pixelSize() >= 5 || TEST_RFLAGS(RendererOptions::PrintAllLabels)) && tranformedRoadPath.length() > strWidth) {
+        if ((font.pixelSize() >= 5 || TEST_RFLAGS_FEATURE_PAINTER(RendererOptions::PrintAllLabels)) && tranformedRoadPath.length() > strWidth) {
             thePainter->setFont(font);
 
             int repeat = int((tranformedRoadPath.length() / ((strWidth * LABEL_PATH_DISTANCE))) - 0.5);

--- a/src/Render/MapRenderer.cpp
+++ b/src/Render/MapRenderer.cpp
@@ -18,7 +18,7 @@
 #include "ImageMapLayer.h"
 #include "LineF.h"
 
-#define TEST_RFLAGS(x) theOptions.options.testFlag(x)
+#define TEST_RFLAGS_MAP_RENDERER(x) theOptions.options.testFlag(x)
 #define TEST_RENDERER_RFLAGS(x) r->theOptions.options.testFlag(x)
 
 void BackgroundStyleLayer::draw(Way* R)
@@ -260,10 +260,10 @@ void MapRenderer::render(
             NodeWidth = M_PREFS->getNodeSize();
     }
 
-    bool bgLayerVisible = TEST_RFLAGS(RendererOptions::BackgroundVisible);
-    bool fgLayerVisible = TEST_RFLAGS(RendererOptions::ForegroundVisible);
-    bool tchpLayerVisible = TEST_RFLAGS(RendererOptions::TouchupVisible);
-    bool lblLayerVisible = TEST_RFLAGS(RendererOptions::NamesVisible);
+    bool bgLayerVisible = TEST_RFLAGS_MAP_RENDERER(RendererOptions::BackgroundVisible);
+    bool fgLayerVisible = TEST_RFLAGS_MAP_RENDERER(RendererOptions::ForegroundVisible);
+    bool tchpLayerVisible = TEST_RFLAGS_MAP_RENDERER(RendererOptions::TouchupVisible);
+    bool lblLayerVisible = TEST_RFLAGS_MAP_RENDERER(RendererOptions::NamesVisible);
 
     QMap<RenderPriority, QSet<Feature*> >::const_iterator itm;
     QMap<RenderPriority, QSet<Feature*> >::const_iterator itmCur;
@@ -284,7 +284,7 @@ void MapRenderer::render(
             {
                 for (it = itm.value().constBegin(); it != itm.value().constEnd(); ++it) {
                     qreal alpha = (*it)->getAlpha();
-                    if ((*it)->isReadonly() && !TEST_RFLAGS(RendererOptions::ForPrinting))
+                    if ((*it)->isReadonly() && !TEST_RFLAGS_MAP_RENDERER(RendererOptions::ForPrinting))
                         alpha /= 2.0;
                     if (alpha != 1.) {
                         P->save();
@@ -315,7 +315,7 @@ void MapRenderer::render(
             {
                 for (it = itm.value().constBegin(); it != itm.value().constEnd(); ++it) {
                     qreal alpha = (*it)->getAlpha();
-                    if ((*it)->isReadonly() && !TEST_RFLAGS(RendererOptions::ForPrinting))
+                    if ((*it)->isReadonly() && !TEST_RFLAGS_MAP_RENDERER(RendererOptions::ForPrinting))
                         alpha /= 2.0;
                     if (alpha != 1.) {
                         P->save();
@@ -345,7 +345,7 @@ void MapRenderer::render(
         for (itm = theFeatures.constBegin() ;itm != theFeatures.constEnd(); ++itm) {
             for (it = itm.value().constBegin(); it != itm.value().constEnd(); ++it) {
                 qreal alpha = (*it)->getAlpha();
-                if ((*it)->isReadonly() && !TEST_RFLAGS(RendererOptions::ForPrinting))
+                if ((*it)->isReadonly() && !TEST_RFLAGS_MAP_RENDERER(RendererOptions::ForPrinting))
                     alpha /= 2.0;
                 if (alpha != 1.) {
                     P->save();
@@ -375,7 +375,7 @@ void MapRenderer::render(
             for (it = itm.value().constBegin(); it != itm.value().constEnd(); ++it) {
                 P->save();
                 qreal alpha = (*it)->getAlpha();
-                if ((*it)->isReadonly() && !TEST_RFLAGS(RendererOptions::ForPrinting))
+                if ((*it)->isReadonly() && !TEST_RFLAGS_MAP_RENDERER(RendererOptions::ForPrinting))
                     alpha /= 2.0;
                 P->setOpacity(alpha);
 

--- a/src/common/MapView.cpp
+++ b/src/common/MapView.cpp
@@ -39,7 +39,7 @@
 // from wikipedia
 #define EQUATORIALRADIUS 6378137.0
 #define LAT_ANG_PER_M 1.0 / EQUATORIALRADIUS
-#define TEST_RFLAGS(x) p->ROptions.options.testFlag(x)
+#define TEST_RFLAGS_MAP_VIEW(x) p->ROptions.options.testFlag(x)
 
 class MapViewPrivate
 {
@@ -169,7 +169,7 @@ void MapView::invalidate(bool updateWireframe, bool updateOsmMap, bool updateBgM
 {
     if (updateOsmMap) {
         if (!M_PREFS->getWireframeView()) {
-            if (!TEST_RFLAGS(RendererOptions::Interacting))
+            if (!TEST_RFLAGS_MAP_VIEW(RendererOptions::Interacting))
                 p->osmLayer->forceRedraw(p->theProjection, p->theTransform, rect(), p->PixelPerM, p->ROptions);
             else if (M_PREFS->getEditRendering() == 2)
                 p->osmLayer->forceRedraw(p->theProjection, p->theTransform, rect(), p->PixelPerM, p->ROptions);
@@ -298,7 +298,7 @@ void MapView::paintEvent(QPaintEvent * anEvent)
     if (M_PREFS->getWireframeView() || !p->osmLayer->isRenderingDone() || M_PREFS->getEditRendering() == 1)
         P.drawPixmap(p->theVectorPanDelta, *StaticWireframe);
     if (!M_PREFS->getWireframeView())
-        if (!(TEST_RFLAGS(RendererOptions::Interacting) && M_PREFS->getEditRendering() == 1))
+        if (!(TEST_RFLAGS_MAP_VIEW(RendererOptions::Interacting) && M_PREFS->getEditRendering() == 1))
             drawFeatures(P);
     P.drawPixmap(p->theVectorPanDelta, *StaticTouchup);
 
@@ -357,7 +357,7 @@ void MapView::paintEvent(QPaintEvent * anEvent)
 void MapView::drawScale(QPainter & P)
 {
 
-    if (!TEST_RFLAGS(RendererOptions::ScaleVisible))
+    if (!TEST_RFLAGS_MAP_VIEW(RendererOptions::ScaleVisible))
         return;
 
     errno = 0;
@@ -445,7 +445,7 @@ void floodFill(QImage& theImage, const QPoint& P, const QRgb& targetColor, const
 
 void MapView::drawLatLonGrid(QPainter & P)
 {
-    if (!TEST_RFLAGS(RendererOptions::LatLonGridVisible))
+    if (!TEST_RFLAGS_MAP_VIEW(RendererOptions::LatLonGridVisible))
         return;
 
     QPointF origin(0., 0.);
@@ -552,7 +552,7 @@ void MapView::drawFeatures(QPainter & P)
 
 void MapView::drawDownloadAreas(QPainter & P)
 {
-    if (!TEST_RFLAGS(RendererOptions::DownloadedVisible))
+    if (!TEST_RFLAGS_MAP_VIEW(RendererOptions::DownloadedVisible))
         return;
 
     P.save();
@@ -1001,7 +1001,7 @@ void MapView::setViewport(const CoordBox & TargetMap,
 
     p->ZoomLevel = p->theTransform.m11();
 
-    if (TEST_RFLAGS(RendererOptions::LockZoom) && p->theDocument) {
+    if (TEST_RFLAGS_MAP_VIEW(RendererOptions::LockZoom) && p->theDocument) {
         ImageMapLayer* l = NULL;
         for (LayerIterator<ImageMapLayer*> ImgIt(p->theDocument); !ImgIt.isEnd(); ++ImgIt) {
             l = ImgIt.get();
@@ -1027,7 +1027,7 @@ void MapView::zoom(qreal d, const QPoint & Around)
         return;
 
     qreal z = d;
-    if (TEST_RFLAGS(RendererOptions::LockZoom)) {
+    if (TEST_RFLAGS_MAP_VIEW(RendererOptions::LockZoom)) {
         ImageMapLayer* l = NULL;
         for (LayerIterator<ImageMapLayer*> ImgIt(p->theDocument); !ImgIt.isEnd(); ++ImgIt) {
             l = ImgIt.get();
@@ -1087,7 +1087,7 @@ void MapView::zoom(qreal d, const QPoint & Around,
 
 void MapView::adjustZoomToBoris()
 {
-    if (TEST_RFLAGS(RendererOptions::LockZoom)) {
+    if (TEST_RFLAGS_MAP_VIEW(RendererOptions::LockZoom)) {
         ImageMapLayer* l = NULL;
         for (LayerIterator<ImageMapLayer*> ImgIt(p->theDocument); !ImgIt.isEnd(); ++ImgIt) {
             l = ImgIt.get();


### PR DESCRIPTION
I was curious if merkaartor can be built with `CMAKE_UNITY_BUILD" turned on. Only a few build errors needed to be fixed.

I also changed how the QtLockedFile class is built. It was compiled once without the namespace and once with the namespace. This interfered with the unity build. It is now only built within the namespace.  

A full release build now takes on my machine, a Ryzen 9 3900X about 15 seconds. Before it was about 25 seconds.
