### PR TITLE
Implemented a source field in the upload dialog.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4289,9 +4289,10 @@ void MainWindow::syncOSM(const QString& aWeb, const QString& aUser, const QStrin
     DirtyListBuild Future;
     theDocument->history().buildDirtyList(Future);
     DirtyListDescriber Describer(theDocument,Future);
-    if (Describer.showChanges(this) && Describer.tasks()) {
+    ChangesetInfo changesetInfo;
+    if (Describer.showChanges(this, changesetInfo) && Describer.tasks()) {
         Future.resetUpdates();
-        DirtyListExecutorOSC Exec(theDocument,Future,aWeb,aUser,aPwd,Describer.tasks());
+        DirtyListExecutorOSC Exec(theDocument,Future,changesetInfo,aWeb,aUser,aPwd,Describer.tasks());
         if (Exec.executeChanges(this)) {
             if (M_PREFS->getAutoHistoryCleanup() && !theDocument->getDirtyOrOriginLayer()->getDirtySize())
                 theDocument->history().cleanup();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4289,7 +4289,7 @@ void MainWindow::syncOSM(const QString& aWeb, const QString& aUser, const QStrin
     DirtyListBuild Future;
     theDocument->history().buildDirtyList(Future);
     DirtyListDescriber Describer(theDocument,Future);
-    ChangesetInfo changesetInfo;
+    ChangesetInfo changesetInfo = {aWeb, "", ""};
     if (Describer.showChanges(this, changesetInfo) && Describer.tasks()) {
         Future.resetUpdates();
         DirtyListExecutorOSC Exec(theDocument,Future,changesetInfo,aWeb,aUser,aPwd,Describer.tasks());

--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -1257,7 +1257,7 @@ M_PARAM_IMPLEMENT_INT_DELAYED(TagListFirstColumnWidth, visual, 20)
 M_PARAM_IMPLEMENT_BOOL(TranslateTags, locale, true)
 
 /* Background */
-M_PARAM_IMPLEMENT_BOOL(AutoSourceTag, backgroundImage, true)
+M_PARAM_IMPLEMENT_BOOL(AutoSourceTag, backgroundImage, false)
 
 /* Data */
 M_PARAM_IMPLEMENT_STRING(MapdustUrl, data, "http://www.mapdust.com/feed?lang=en&ft=wrong_turn,bad_routing,oneway_road,blocked_street,missing_street,wrong_roundabout,missing_speedlimit,other&fd=1&minR=&maxR=")

--- a/src/Sync/DirtyList.cpp
+++ b/src/Sync/DirtyList.cpp
@@ -25,8 +25,6 @@ int glbNodesAdded, glbNodesUpdated, glbNodesDeleted;
 int glbWaysAdded, glbWaysUpdated, glbWaysDeleted;
 int glbRelationsAdded, glbRelationsUpdated, glbRelationsDeleted;
 
-QString glbChangeSetComment;
-
 QString stripToOSMId(const IFeature::FId& id)
 {
     return QString::number(id.numId);
@@ -293,7 +291,7 @@ int DirtyListDescriber::tasks() const
     return Task;
 }
 
-bool DirtyListDescriber::showChanges(QWidget* aParent)
+bool DirtyListDescriber::showChanges(QWidget* aParent, ChangesetInfo& changesetInfo)
 {
     QDialog* dlg = new QDialog(aParent);
     Ui.setupUi(dlg);
@@ -315,15 +313,15 @@ bool DirtyListDescriber::showChanges(QWidget* aParent)
     Ui.lblUpdated->setText(QString::number(glbUpdated));
     Ui.lblDeleted->setText(QString::number(glbDeleted));
 
-    //Ui.edChangesetComment->setText(glbChangeSetComment);
-    //Ui.edChangesetComment->selectAll();
+    Ui.edSources->setText(theDocument->getCurrentSourceTags().join(";"));
 
     bool ok = false;
     while (!ok) {
         if (dlg->exec() == QDialog::Accepted) {
             /* Dialog was accepted, check for non-empty comment */
             if (!Ui.edChangesetComment->text().isEmpty()) {
-                glbChangeSetComment = Ui.edChangesetComment->text();
+                changesetInfo.comment = Ui.edChangesetComment->text();
+                changesetInfo.source = Ui.edSources->text();
                 ok = true;
             } else if (QMessageBox::question(NULL,
                         QApplication::tr("Use empty changeset comment?"),

--- a/src/Sync/DirtyList.cpp
+++ b/src/Sync/DirtyList.cpp
@@ -312,6 +312,7 @@ bool DirtyListDescriber::showChanges(QWidget* aParent, ChangesetInfo& changesetI
     Ui.lblAdded->setText(QString::number(glbAdded));
     Ui.lblUpdated->setText(QString::number(glbUpdated));
     Ui.lblDeleted->setText(QString::number(glbDeleted));
+    Ui.lblServerUrl->setText(changesetInfo.serverUrl);
 
     Ui.edSources->setText(theDocument->getCurrentSourceTags().join(";"));
 

--- a/src/Sync/DirtyList.h
+++ b/src/Sync/DirtyList.h
@@ -20,6 +20,13 @@ class QWidget;
 #include <utility>
 #include <QList>
 
+/** Changeset information container class. */
+class ChangesetInfo {
+    public:
+        QString comment;
+        QString source;
+};
+
 class DirtyList
 {
     public:
@@ -107,7 +114,17 @@ class DirtyListDescriber : public DirtyListVisit
         virtual bool eraseRoad(Way* R);
         virtual bool eraseRelation(Relation* R);
 
-        bool showChanges(QWidget* Parent);
+        /**
+         * Display changeset upload dialog. If approved by user, returns true
+         * and info will be filled-in with dialog data. Returns false
+         * otherwise.
+         *
+         * @param Parent    Qt parent window
+         * @param info      Changeset info filled in by the user (left as is if cancelled).
+         *
+         * @return          true if changes approved by user
+         */
+        bool showChanges(QWidget* Parent, ChangesetInfo& info);
         int tasks() const;
 
     private:

--- a/src/Sync/DirtyList.h
+++ b/src/Sync/DirtyList.h
@@ -23,6 +23,7 @@ class QWidget;
 /** Changeset information container class. */
 class ChangesetInfo {
     public:
+        QString serverUrl;
         QString comment;
         QString source;
 };
@@ -120,7 +121,8 @@ class DirtyListDescriber : public DirtyListVisit
          * otherwise.
          *
          * @param Parent    Qt parent window
-         * @param info      Changeset info filled in by the user (left as is if cancelled).
+         * @param info      Changeset info filled with `comment` and `source`
+         *                  in by the user (left as is if cancelled).
          *
          * @return          true if changes approved by user
          */

--- a/src/Sync/DirtyListExecutorOSC.h
+++ b/src/Sync/DirtyListExecutorOSC.h
@@ -26,7 +26,7 @@ class DirtyListExecutorOSC : public QObject, public DirtyListVisit
 
 public:
     DirtyListExecutorOSC(Document* aDoc, const DirtyListBuild& aFuture);
-    DirtyListExecutorOSC(Document* aDoc, const DirtyListBuild& aFuture, const QString& aWeb, const QString& aUser, const QString& aPwd, int aTasks);
+    DirtyListExecutorOSC(Document* aDoc, const DirtyListBuild& aFuture, const ChangesetInfo& info, const QString& aWeb, const QString& aUser, const QString& aPwd, int aTasks);
     virtual ~DirtyListExecutorOSC();
 
     void OscCreate(Feature* F);
@@ -61,6 +61,7 @@ private:
     Downloader* theDownloader;
     QString ChangeSetId;
     QString LastAction;
+    ChangesetInfo changesetInfo;
 };
 
 

--- a/src/Sync/SyncListDialog.ui
+++ b/src/Sync/SyncListDialog.ui
@@ -17,34 +17,65 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
       <widget class="QLabel" name="lblChangesetComment">
        <property name="text">
         <string>Comment</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="1">
       <widget class="QLineEdit" name="edChangesetComment"/>
      </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>A good comment should concisely and adequately describe the edit.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="edSources"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Sources</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_11">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Semicolon separated list of sources for these changes. See &lt;a href=&quot;https://wiki.openstreetmap.org/wiki/Key:source&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;source=*&lt;/span&gt;&lt;/a&gt; for possible values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>A good comment should concisely and adequately describe the edit.</string>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="Line" name="line">
@@ -247,7 +278,16 @@
      <property name="spacing">
       <number>6</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>

--- a/src/Sync/SyncListDialog.ui
+++ b/src/Sync/SyncListDialog.ui
@@ -31,6 +31,12 @@
    </property>
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="horizontalSpacing">
+      <number>12</number>
+     </property>
+     <property name="verticalSpacing">
+      <number>6</number>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="lblChangesetComment">
        <property name="text">
@@ -53,17 +59,31 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QLineEdit" name="edSources"/>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Sources</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>Server URL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="lblServerUrl">
+       <property name="text">
+        <string notr="true">....</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
       <widget class="QLabel" name="label_11">
        <property name="font">
         <font>

--- a/src/common/Document.cpp
+++ b/src/common/Document.cpp
@@ -909,8 +909,9 @@ QStringList Document::getCurrentSourceTags()
     for (LayerIterator<ImageMapLayer*> ImgIt(this); !ImgIt.isEnd(); ++ImgIt) {
         if (ImgIt.get()->isVisible()) {
             QString s = ImgIt.get()->getMapAdapter()->getSourceTag();
-            if (!s.isEmpty())
-                theSrc << ImgIt.get()->getMapAdapter()->getSourceTag();
+            if ((!s.isEmpty()) && (!theSrc.contains(s))) {
+                theSrc << s;
+            }
         }
     }
     return theSrc;


### PR DESCRIPTION
This is a reimplementation of PR #161 . It adds:
- A text edit in the upload dialog to review and change source tags if necessary.
- A text field with server URL for upload (useful when using non-upstream server, like a test API).
- More robust xml composition (previously, wrongly formated comment could have broken the request xml).