### PR TITLE
Fix build with GPSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if (GEOIMAGE)
 endif()
 
 if (GPSD)
-    list(APPEND PKGCONFIG_REQUIRED_LIBS gpsd)
+    list(APPEND PKGCONFIG_REQUIRED_LIBS libgps)
     add_definitions(-DUSE_GPS=1)
 endif()
 


### PR DESCRIPTION
The following error was observed (https://github.com/NixOS/nixpkgs/pull/259434#issuecomment-1751342842) when building Merkaartor with GPSD support:

```
error: builder for '/nix/store/b4c5hs4509g37l7y9kmb1ysd1916jjrj-merkaartor-0.19.0.drv' failed with exit code 1;
       last 10 log lines:
       > -- Checking for modules 'gdal;proj;exiv2;gpsd'
       > --   No package 'gpsd' found
       > CMake Error at /nix/store/yi235g10sp8jx939zpfli0s74154ph3v-cmake-3.26.4/share/cmake-3.26/Modules/FindPkgConfig.cmake:607 (message):
       >   A required package was not found
       > Call Stack (most recent call first):
       >   /nix/store/yi235g10sp8jx939zpfli0s74154ph3v-cmake-3.26.4/share/cmake-3.26/Modules/FindPkgConfig.cmake:829 (_pkg_check_modules_internal)
       >   CMakeLists.txt:523 (pkg_check_modules)
       >
       >
       > -- Configuring incomplete, errors occurred!
```

It turns out that the package is known as `libgps` instead.