### PR TITLE
Use CMAKE_INSTALL_LIBDIR for library installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@ project(merkaartor VERSION ${VCS_VERSION})
 # compatibility.
 # Using configure_file() allows us to store the metadata in a .cpp file, thus
 # only rebuilding that one and linking.
-set(SHARE_DIR ${CMAKE_INSTALL_PREFIX}/share/merkaartor)
-set(LIB_DIR   ${CMAKE_INSTALL_PREFIX}/lib/merkaartor)
+include(GNUInstallDirs)
+set(SHARE_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/merkaartor)
+set(LIB_DIR   ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/merkaartor)
 configure_file("${PROJECT_SOURCE_DIR}/cmake/build-metadata.cpp.in" "${PROJECT_BINARY_DIR}/build-metadata.cpp" @ONLY)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/plugins/plugins.cmake
+++ b/plugins/plugins.cmake
@@ -2,7 +2,7 @@
 if (APPLE)
 set(PLUGINS_INSTALL_POSTFIX "merkaartor.app/Contents/plugins")
 else()
-set(PLUGINS_INSTALL_POSTFIX "lib/merkaartor/plugins")
+set(PLUGINS_INSTALL_POSTFIX "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/merkaartor/plugins")
 endif()
 
 function(MerkaartorAddPlugin)


### PR DESCRIPTION
Warning: only tested on Linux.

We need to be able to use path other than /usr/lib. RPM based distro generally /usr/lib64, and Debian based do their thing too. Using GNUInstallDirs allow determining the correct path.