### PR TITLE
Fix pkg-config name for gpsd.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if (GEOIMAGE)
 endif()
 
 if (GPSD)
-    list(APPEND PKGCONFIG_REQUIRED_LIBS gpsd)
+    list(APPEND PKGCONFIG_REQUIRED_LIBS libgps)
     add_definitions(-DUSE_GPS=1)
 endif()
 


### PR DESCRIPTION
The Debian package failed to build with CMake because the pkg-config name for gpsd is incorrect.

libgps-dev provides libgps.pc.