### PR TITLE
Separated makeBoundaryIcon to its own file to fix UNITY build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,8 @@ src/Utils/PixmapWidget.cpp
 src/Utils/TagSelector.cpp
 src/Utils/SvgCache.h
 src/Utils/RemoteControlServer.cpp
+src/Utils/BoundaryIcon.cpp
+src/Utils/BoundaryIcon.h
 src/QToolBarDialog/qttoolbardialog.h
 src/QToolBarDialog/qttoolbardialog.cpp
 src/QToolBarDialog/qttoolbardialog.ui

--- a/src/PaintStyle/PaintStyleEditor.cpp
+++ b/src/PaintStyle/PaintStyleEditor.cpp
@@ -4,6 +4,7 @@
 #include "Painter.h"
 #include "MainWindow.h"
 #include "Document.h"
+#include "BoundaryIcon.h"
 
 #include "SelectionDialog.h"
 
@@ -15,17 +16,6 @@
 #include <QPainter>
 #include <QPixmap>
 #include <QToolButton>
-
-static void makeBoundaryIcon(QToolButton* bt, QColor C)
-{
-    QPixmap pm(36, 18);
-    pm.fill(QColor(255, 255, 255));
-    QPainter p(&pm);
-    p.setPen(C);
-    p.setBrush(C);
-    p.drawRect(0, 6, 36, 6);
-    bt->setIcon(pm);
-}
 
 PaintStyleEditor::PaintStyleEditor(QWidget *aParent, const GlobalPainter& aGlobalPainter, const QList<Painter>& aPainters)
     : QDialog(aParent), theGlobalPainter(aGlobalPainter), thePainters(aPainters), FreezeUpdate(true)

--- a/src/Preferences/PreferencesDialog.cpp
+++ b/src/Preferences/PreferencesDialog.cpp
@@ -16,6 +16,7 @@
 #include "Document.h"
 #include "Feature.h"
 #include "PropertiesDock.h"
+#include "BoundaryIcon.h"
 
 #include <QFileDialog>
 #include <QColorDialog>
@@ -23,18 +24,6 @@
 #include <QPainter>
 #include <QStyleFactory>
 #include <QNetworkProxy>
-
-
-static void makeBoundaryIcon(QToolButton* bt, QColor C)
-{
-    QPixmap pm(36, 18);
-    pm.fill(QColor(255, 255, 255));
-    QPainter p(&pm);
-    p.setPen(C);
-    p.setBrush(C);
-    p.drawRect(0, 6, 36, 6);
-    bt->setIcon(pm);
-}
 
 OsmServerWidget::OsmServerWidget(QWidget * parent, Qt::WindowFlags f)
     : QWidget(parent, f)

--- a/src/Utils/BoundaryIcon.cpp
+++ b/src/Utils/BoundaryIcon.cpp
@@ -1,0 +1,19 @@
+#ifndef BOUNDARYICON_H
+#define BOUNDARYICON_H
+
+#include "BoundaryIcon.h"
+
+#include <QPainter>
+
+void makeBoundaryIcon(QToolButton* bt, QColor C)
+{
+    QPixmap pm(36, 18);
+    pm.fill(QColor(255, 255, 255));
+    QPainter p(&pm);
+    p.setPen(C);
+    p.setBrush(C);
+    p.drawRect(0, 6, 36, 6);
+    bt->setIcon(pm);
+}
+
+#endif // BOUNDARYICON_H

--- a/src/Utils/BoundaryIcon.h
+++ b/src/Utils/BoundaryIcon.h
@@ -1,0 +1,9 @@
+#ifndef __BOUNDARYICON_H__
+#define __BOUNDARYICON_H__
+
+#include <QToolButton>
+#include <QColor>
+
+void makeBoundaryIcon(QToolButton* bt, QColor C);
+
+#endif


### PR DESCRIPTION
This fixes an issue with unity build. Unnoticed until (presumably) a compiler update.