### PR TITLE
Remove references to the AUR in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Travis-CI (Linux, Windows and Mac OS X) [![Build Status](https://travis-ci.org/o
 Binary installation files are available for various Linux distributions and Windows. 
 
 These Linux distributions are known to provide current versions of Merkaartor:
- - Arch via [AUR](https://aur.archlinux.org/packages/merkaartor-git/) ([git clone url](https://aur.archlinux.org/merkaartor-git.git))
+ - Arch
  - Debian
  - Fedora
  - Gentoo


### PR DESCRIPTION
Since there is a package for Merkaartor in the extra repository (merkaartor), it is preferable to use that instead of the package in the AUR (which is also out-of-date).