### PR TITLE
Fix build with GEOIMAGE=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,9 +371,7 @@ src/Docks/MinimumRelationProperties.ui
 src/Docks/PropertiesDock.h
 src/Docks/DirtyDock.h
 src/Docks/StyleDock.cpp
-src/Docks/GeoImageDock.cpp
 src/Docks/DirtyDock.ui
-src/Docks/GeoImageDock.h
 src/Docks/MDockAncestor.cpp
 src/Docks/MinimumTrackPointProperties.ui
 src/Docks/StyleDock.h
@@ -507,6 +505,7 @@ endif()
 
 if (GEOIMAGE)
     list(APPEND PKGCONFIG_REQUIRED_LIBS exiv2)
+    list(APPEND merkaartor_SRCS src/Docks/GeoImageDock.cpp src/Docks/GeoImageDock.h)
     add_definitions(-DGEOIMAGE=1)
 endif()
 


### PR DESCRIPTION
```sh
merkaartor> /tmp/nix-build-merkaartor-0.20.0.drv-1/source/src/Docks/GeoImageDock.cpp:9:10: fatal error: 'exiv2/exiv2.hpp' file not found
merkaartor> #include <exiv2/exiv2.hpp>
merkaartor>          ^~~~~~~~~~~~~~~~~
merkaartor> [ 93%] Building CXX object CMakeFiles/merkaartor.dir/3rdparty/qtsingleapplication-2.6_1-opensource/src/qtlockedfile.cpp.o
merkaartor> 1 error generated.
merkaartor> make[2]: *** [CMakeFiles/merkaartor.dir/build.make:2211: CMakeFiles/merkaartor.dir/src/Docks/GeoImageDock.cpp.o] Error 1
```