### PR TITLE
Allow smaller window sizes

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -228,8 +228,11 @@ MainWindow::MainWindow(QWidget *parent)
     MeterPerPixelLabel = new QLabel(this);
     AdjusmentMeterLabel = new QLabel(this);
 
+    ViewportStatusLabel->setWordWrap(true);
+    ViewportStatusLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
     pbImages = new QProgressBar(this);
-    statusBar()->addPermanentWidget(ViewportStatusLabel);
+    statusBar()->addPermanentWidget(ViewportStatusLabel, true);
     statusBar()->addPermanentWidget(pbImages);
     statusBar()->addPermanentWidget(MeterPerPixelLabel);
     statusBar()->addPermanentWidget(AdjusmentMeterLabel);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -242,7 +242,7 @@ MainWindow::MainWindow(QWidget *parent)
     updateLanguage();
 
     ViewportStatusLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    pbImages->setMaximumWidth(200);
+    pbImages->setMaximumWidth(50);
     pbImages->setFormat(tr("tile %v / %m"));
 #ifdef _MOBILE
     pbImages->setVisible(false);


### PR DESCRIPTION
Allows smaller window sizes by word wrapping the viewport status and shrinking the image load progress bar, fixing issue #297 .