### PR TITLE
Fixed snap management in create node.

### DIFF
--- a/src/Interactions/CreateNodeInteraction.cpp
+++ b/src/Interactions/CreateNodeInteraction.cpp
@@ -45,6 +45,8 @@ QString CreateNodeInteraction::toHtml()
 void CreateNodeInteraction::snapMousePressEvent(QMouseEvent * ev, Feature* aFeat)
 {
     if (CAST_NODE(aFeat)) {
+        clearNoSnap();
+        addToNoSnap(aFeat);
         return theMoveInteraction->snapMousePressEvent(ev, aFeat);
     } else {
         SAFE_DELETE(theMoveInteraction);
@@ -77,6 +79,7 @@ void CreateNodeInteraction::snapMouseReleaseEvent(QMouseEvent * ev, Feature* aFe
 {
     if (theMoveInteraction) {
         theMoveInteraction->snapMouseReleaseEvent(ev, aFeat);
+        clearNoSnap();
         return;
     }
 


### PR DESCRIPTION
Snapping will no longer take into account the current node, allowing free movement on the canvas. Fixes issue #275 .