### PR TITLE
Fixed a crash on download when no server is loaded from config.

### DIFF
--- a/src/Preferences/MerkaartorPreferences.cpp
+++ b/src/Preferences/MerkaartorPreferences.cpp
@@ -630,6 +630,11 @@ void MerkaartorPreferences::initialize()
 
     }
 
+    if (theOsmServers.size() == 0) {
+        theOsmServers.append(defaultOsmServerInfo);
+        qDebug(lc_MerkaartorPreferences) << "No OSM servers found, adding default server.";
+    }
+
     //Ensure we have a CacheDir value in QSettings
     if (!g_Merk_Ignore_Preferences)
         Sets->setValue("backgroundImage/CacheDir", Sets->value("backgroundImage/CacheDir", HOMEDIR + "/BackgroundCache"));

--- a/src/Utils/OsmServer.h
+++ b/src/Utils/OsmServer.h
@@ -46,6 +46,8 @@ struct OsmServerInfo
     int CfgVersion = 1;
 };
 
+OsmServerInfo const defaultOsmServerInfo = OsmServerInfo{true, OsmServerInfo::AuthType::OAuth2Redirect, "https://www.openstreetmap.org/", "", ""};
+
 class IOsmServerImpl : public QObject {
     Q_OBJECT
 


### PR DESCRIPTION
Default osm server is loaded with no credentials.

Fixes issue #307.