### PR TITLE
Fix build with GPSD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,7 @@ endif()
 
 if (GPSD)
     list(APPEND PKGCONFIG_REQUIRED_LIBS libgps)
-    add_definitions(-DUSE_GPS=1)
+    add_definitions(-DUSE_GPSD_LIB=1)
 endif()
 
 if (LIBPROXY)


### PR DESCRIPTION
It's defined as `USE_GPSD_LIB` in `qgpsdevice.cpp`.